### PR TITLE
feat: replace edm.TimeSeries with timedatamodel.TimeSeriesTable on EnergyAsset

### DIFF
--- a/energydatamodel/__init__.py
+++ b/energydatamodel/__init__.py
@@ -5,10 +5,18 @@ from shapely.geometry import Point
 import pytz
 from uuid import uuid4
 
+from timedatamodel import (
+    TimeSeries,
+    TimeSeriesTable,
+    DataType,
+    DataShape,
+    Frequency,
+    GeoLocation as TDMGeoLocation,
+)
+
 from .abstract import AbstractClass
 from .geospatial import GeoLocation, Location, LineString, GeoPolygon, GeoMultiPolygon
-from .base import EnergyAsset, TimeSeries, Sensor, EnergyCollection
-from .timeseries import ElectricityDemand, ElectricityConsumption, ElectricityAreaDemand, ElectricityAreaConsumption, ElectricitySupply, ElectricityProduction, ElectricityAreaSupply, ElectricityAreaProduction, HeatingDemand, HeatingConsumption, HeatingAreaDemand
+from .base import EnergyAsset, Sensor, EnergyCollection
 from .building import House, Building
 from .solar import FixedMount, SingleAxisTrackerMount, PVArray, PVSystem, SolarPowerArea
 from .wind import WindTurbine, WindFarm, WindPowerArea
@@ -18,4 +26,4 @@ from .hydro import Reservoir, HydroTurbine, HydroPowerPlant
 from .powergrid import Carrier, Bus, Transformer, Link, SubNetwork, Network
 from .collection import Site, EnergyCommunity, Portfolio
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'

--- a/energydatamodel/base.py
+++ b/energydatamodel/base.py
@@ -8,49 +8,25 @@ from shapely.geometry import mapping, Point, Polygon, LineString
 import pytz
 from uuid import uuid4
 from anytree import Node, RenderTree
+from timedatamodel import TimeSeriesTable
 
 import energydatamodel as edm
 from energydatamodel import AbstractClass, Location
 
-@dataclass(repr=False, kw_only=True)
-class TimeSeries(AbstractClass):
-    name: t.Optional[str] = None
-    df: t.Optional[pd.DataFrame] = None
-    column_names: t.Optional[t.Union[str, int, t.Tuple[str], t.Tuple[int]]] = None
-    filename: t.Optional[str] = None
-
-    def get_data(self) -> pd.Series: 
-        """
-        Get data from :class:`TimeSeries` as a :class:`pandas.Series`.
-
-        Returns:
-            The time series data. 
-        """
-
-        s = self.df.loc[:, [self.column_name]]
-        return s
-
-    def plot(self, start_date: t.Union[str, pd.DatetimeIndex], end_date: t.Union[str, pd.DatetimeIndex]) -> plt.Axes: 
-        """
-        Plots a pandas Series using its built-in plot method.
-
-        Args:
-            start_date: The start date for the plot. 
-            end_date: The end date for the plot. 
-            
-        Returns:
-            The Matplotlib Axes object of the plot.
-        """
-
-        series = self.df.loc[start_date:end_date, [self.column_name]]
-        ax = series.plot()
-
-        return ax
-
 
 @dataclass(repr=False, kw_only=True)
 class EnergyAsset(AbstractClass):
-    """Get data from :class: `TimeSeries`"""
+    """Base class for all energy assets.
+
+    The ``timeseries`` field holds a :class:`timedatamodel.TimeSeriesTable` —
+    a Polars-backed multivariate container where each column is one signal
+    (e.g. ``ActivePower``, ``WindSpeed``) and per-column metadata (unit,
+    data_type, location, labels) is preserved alongside the data.
+
+    Use :meth:`timeseries.select_column` to extract a single signal as a
+    :class:`timedatamodel.TimeSeries`, or :meth:`timeseries.to_pandas` to
+    convert the whole table to a pandas DataFrame.
+    """
 
     name: t.Optional[str] = None
     location: t.Optional[Location] = None
@@ -58,36 +34,48 @@ class EnergyAsset(AbstractClass):
     longitude: t.Optional[float] = None
     altitude: t.Optional[float] = None
     tz: t.Optional[pytz.timezone] = None
-    timeseries: t.Optional[TimeSeries] = None
+    timeseries: t.Optional[TimeSeriesTable] = None
 
     def __post_init__(self):
-        if self.location is None: 
+        if self.location is None:
             if self.longitude is not None and self.latitude is not None:
                 self.location = Location(self.longitude, self.latitude)
-            if self.altitude is not None: 
+            if self.altitude is not None:
                 self.location.altitude = self.altitude
-            if self.tz is not None: 
+            if self.tz is not None:
                 self.location.tz = self.tz
 
     def get_location(self):
         return self.location
-    
-    def plot_timeseries(self, 
-                        start_date: t.Optional[t.Union[str, pd.DatetimeIndex]] = None, 
-                        end_date: t.Optional[t.Union[str, pd.DatetimeIndex]] = None) -> plt.Axes: 
-        """
-        Plots a pandas Series using its built-in plot method.
+
+    def plot_timeseries(self,
+                        columns: t.Optional[t.List[str]] = None,
+                        start_date: t.Optional[str] = None,
+                        end_date: t.Optional[str] = None) -> plt.Axes:
+        """Plot one or more signals from the asset's TimeSeriesTable.
 
         Args:
-            start_date: The start date for the plot. 
-            end_date: The end date for the plot. 
-            
+            columns: Signal names to plot. Defaults to all columns.
+            start_date: ISO 8601 start date string for slicing (inclusive).
+            end_date: ISO 8601 end date string for slicing (inclusive).
+
         Returns:
             The Matplotlib Axes object of the plot.
         """
+        if self.timeseries is None:
+            raise ValueError("No timeseries data attached to this asset.")
 
-        df = self.timeseries.df.loc[start_date:end_date, [self.timeseries.column_name]]
+        df = self.timeseries.to_pandas()
+
+        if columns is not None:
+            df = df[columns]
+
+        if start_date is not None or end_date is not None:
+            df = df.loc[start_date:end_date]
+
         ax = df.plot()
+        ax.set_ylabel("Value")
+        ax.set_title(self.name or self.__class__.__name__)
 
         return ax
 

--- a/energydatamodel/building.py
+++ b/energydatamodel/building.py
@@ -25,7 +25,7 @@ class House(edm.EnergyAsset):
             self.assets.append(assets)
 
     def has_demand(self):
-        return isinstance(self.timeseries, edm.TimeSeries)
+        return self.timeseries is not None
 
     def has_pvsystem(self):
         return any(isinstance(item, edm.PVSystem) for item in self.assets)

--- a/energydatamodel/collection.py
+++ b/energydatamodel/collection.py
@@ -90,35 +90,26 @@ class Portfolio(EnergyCollection):
     """
 
     def plot_timeseries(self, start_date: t.Optional[str] = None, end_date: t.Optional[str] = None, subplots: bool = False) -> Union[t.Tuple[plt.Figure, plt.Axes], t.Tuple[plt.Figure, np.ndarray]]:
-        # Convert start_date and end_date to datetime if they are not None
-        if start_date is not None:
-            start_date = pd.to_datetime(start_date)
-        if end_date is not None:
-            end_date = pd.to_datetime(end_date)
+        assets_with_data = [a for a in self.assets if a.timeseries is not None]
+        if not assets_with_data:
+            raise ValueError("No assets with timeseries data in this portfolio.")
 
-        # Create a single plot or subplots based on the subplots parameter
         if subplots:
-            fig, axes = plt.subplots(len(self.assets), 1, sharex=True, figsize=(10, len(self.assets) * 3))
-            for i, asset in enumerate(self.assets):
-                column = asset.timeseries.column_name
-                df = asset.timeseries.df
-                # Slice the dataframe for the date range
-                df_filtered = df.loc[start_date:end_date, column]
-                if isinstance(axes, np.ndarray):
-                    ax = axes[i]
-                else:
-                    ax = axes
-                df_filtered.plot(ax=ax)
+            fig, axes = plt.subplots(len(assets_with_data), 1, sharex=True, figsize=(10, len(assets_with_data) * 3))
+            for i, asset in enumerate(assets_with_data):
+                df = asset.timeseries.to_pandas().loc[start_date:end_date]
+                ax = axes[i] if isinstance(axes, np.ndarray) else axes
+                df.plot(ax=ax)
+                ax.set_title(asset.name or f"Asset {i}")
             plt.tight_layout()
             return fig, axes
         else:
             fig, ax = plt.subplots()
-            for asset in self.assets:
-                column = asset.timeseries.column_name
-                df = asset.timeseries.df
-                # Slice the dataframe for the date range
-                df_filtered = df.loc[start_date:end_date, column]
-                df_filtered.plot(ax=ax)
+            for asset in assets_with_data:
+                df = asset.timeseries.to_pandas().loc[start_date:end_date]
+                # prefix column names with asset name to avoid collisions
+                df.columns = [f"{asset.name}.{col}" for col in df.columns]
+                df.plot(ax=ax)
             return fig, ax
 
 

--- a/energydatamodel/timeseries.py
+++ b/energydatamodel/timeseries.py
@@ -1,87 +1,56 @@
-from dataclasses import dataclass, field
-import typing as t
-from typing import List, Optional, Union
-import pandas as pd
-from shapely.geometry import Point
-import pytz
-from uuid import uuid4
+"""
+Semantic time series constructors.
 
-import energydatamodel as edm
+Previously this module defined subclasses of the old ``edm.TimeSeries``
+(e.g. ``ElectricityDemand``, ``ElectricitySupply``) that added a ``location``
+or ``area`` field to a pandas-backed wrapper.
 
-#TODO
-# Decide how to and production area fits in. As a time series? As a geospatial area? Or as an energy asset? 
-# It is more of a time series, however, it should hold both capacity and and production data
-# I want geospatial to be more of a base module
-# Should it be its own separate class e.g. EnergySupply, EnergyDemand?
+These subclasses are now **obsolete**. The same semantics are expressed
+directly through :class:`timedatamodel.TimeSeriesTable` metadata:
 
-@dataclass
-class ElectricityDemand(edm.TimeSeries):
-    location: t.Optional[edm.GeoLocation] = None
+- **location** is a first-class per-column field on ``TimeSeriesTable``
+  (and on ``TimeSeries``), so there is no longer any need to subclass in
+  order to carry it.
 
+- **area** (``GeoPolygon`` / ``GeoMultiPolygon``) can be stored as a label
+  or as a custom attribute on the enclosing ``EnergyAsset`` subclass.
 
-ElectricityConsumption = ElectricityDemand
+- The **semantic distinction** between demand, supply, production, and
+  consumption is expressed through :class:`timedatamodel.DataType`:
 
+  ============================================  ==============================
+  Old class                                     New approach
+  ============================================  ==============================
+  ``ElectricityDemand`` / ``ElectricityConsumption``  ``DataType.ACTUAL`` + label ``{"direction": "consumption"}``
+  ``ElectricitySupply`` / ``ElectricityProduction``   ``DataType.ACTUAL`` + label ``{"direction": "production"}``
+  ``ElectricityAreaDemand``                     same, plus ``GeoPolygon`` on the asset
+  ``HeatingDemand`` / ``HeatingConsumption``    ``DataType.ACTUAL`` + label ``{"carrier": "heat", "direction": "consumption"}``
+  ``ElectricityPrice``                          ``DataType.REFERENCE`` + label ``{"carrier": "electricity"}``
+  ``CarbonIntensity``                           ``DataType.REFERENCE`` + label ``{"signal": "carbon_intensity"}``
+  ============================================  ==============================
 
-@dataclass
-class ElectricityAreaDemand(edm.TimeSeries):
-    area: t.Optional[t.Union[edm.GeoPolygon, edm.GeoMultiPolygon]] = None
+Example — electricity production at a point location::
 
+    import timedatamodel as tdm
 
-ElectricityAreaConsumption = ElectricityAreaDemand
+    ts = tdm.TimeSeries.from_pandas(
+        df,                               # pandas DataFrame with valid_time index
+        name="production",
+        unit="kWh",
+        data_type=tdm.DataType.ACTUAL,
+        frequency=tdm.Frequency.PT1H,
+        location=tdm.GeoLocation(longitude=14.97, latitude=63.54),
+        labels={"carrier": "electricity", "direction": "production"},
+    )
 
+Example — building a multi-signal ``TimeSeriesTable`` for a wind turbine::
 
-@dataclass
-class ElectricitySupply(edm.TimeSeries):
-    location: Optional[edm.GeoLocation] = None
+    table = tdm.TimeSeriesTable.from_timeseries(
+        [ts_active_power, ts_wind_speed, ts_iec_state],
+        frequency=tdm.Frequency.PT1H,
+    )
+    turbine.timeseries = table
+"""
 
-
-ElectricityProduction = ElectricitySupply
-
-
-@dataclass
-class ElectricityAreaSupply(edm.TimeSeries):
-    area: t.Optional[t.Union[edm.GeoPolygon, edm.GeoMultiPolygon]] = None
-
-
-ElectricityAreaProduction = ElectricityAreaSupply
-
-
-@dataclass
-class HeatingDemand(edm.TimeSeries):
-    location: Optional[edm.GeoLocation] = None
-
-
-HeatingConsumption = HeatingDemand
-
-@dataclass
-class HeatingAreaDemand(edm.TimeSeries):
-    area: t.Optional[t.Union[edm.GeoPolygon, edm.GeoMultiPolygon]] = None
-
-
-HeatingAreaConsumption = HeatingAreaDemand
-
-
-@dataclass
-class HeatingSupply(edm.TimeSeries):
-    location: Optional[edm.GeoLocation] = None
-
-
-HeatingProduction = HeatingSupply
-
-
-@dataclass
-class HeatingAreaSupply(edm.TimeSeries):
-    area: t.Optional[t.Union[edm.GeoPolygon, edm.GeoMultiPolygon]] = None
-
-
-HeatingAreaProduction = HeatingAreaSupply
-
-
-@dataclass
-class ElectricityPrice(edm.TimeSeries):
-    area: t.Optional[t.Union[edm.GeoPolygon, edm.GeoMultiPolygon]] = None
-
-
-@dataclass
-class CarbonIntensity(edm.TimeSeries):
-    area: Optional[edm.GeoPolygon] = None
+# No classes are defined here. See timedatamodel.TimeSeries,
+# timedatamodel.TimeSeriesTable, and timedatamodel.DataType.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pvlib>=0.12.0",
     "pytz>=2025.1",
     "shapely>=2.0.7",
+    "timedatamodel>=0.1.8",
     "twine>=6.1.0",
 ]
 


### PR DESCRIPTION
## Summary

This PR replaces the internal pandas-backed `edm.TimeSeries` wrapper with [`timedatamodel.TimeSeriesTable`](https://github.com/rebase-energy/TimeDataModel) as the `timeseries` field type on `EnergyAsset`, and adds `timedatamodel` as a package dependency.

### Motivation

A real-world energy asset (wind turbine, PV inverter, battery, etc.) carries **multiple signals** simultaneously — active power, wind speed, state, temperature, and so on. The previous `Optional[TimeSeries]` field could only hold a single pandas DataFrame with a single `column_name`, which forced consumers to either subclass or attach ad-hoc attributes.

`timedatamodel.TimeSeriesTable` is the right fit:
- Polars-backed multivariate container: `valid_time` + N named value columns
- Per-column metadata: `unit`, `data_type`, `frequency`, `location`, `labels`
- `select_column(name)` extracts any single signal back as a `tdm.TimeSeries`
- `from_timeseries([ts1, ts2, ...])` builds the table from individual `TimeSeries` objects
- `to_pandas()` / `to_polars()` for downstream compatibility

### Changes

| File | What changed |
|---|---|
| `base.py` | Removed `edm.TimeSeries` dataclass. Changed `EnergyAsset.timeseries` field type from `Optional[TimeSeries]` to `Optional[TimeSeriesTable]`. Updated `plot_timeseries()` to accept a `columns` filter and use `TimeSeriesTable.to_pandas()`. |
| `timeseries.py` | All subclasses removed (see below). File is now a migration guide with docstring. |
| `__init__.py` | Removed `edm.TimeSeries` and all `timeseries.py` subclass exports. Re-exports `TimeSeries`, `TimeSeriesTable`, `DataType`, `DataShape`, `Frequency` from `timedatamodel` so consumers import them from a single place. Bumped version to `0.0.3`. |
| `building.py` | `House.has_demand()`: `isinstance(self.timeseries, edm.TimeSeries)` → `self.timeseries is not None` |
| `collection.py` | `Portfolio.plot_timeseries()`: updated to use `TimeSeriesTable.to_pandas()`, prefixes column names with asset name to avoid collisions across assets. |
| `pyproject.toml` | Added `timedatamodel>=0.1.8` to dependencies. |

### Why the `timeseries.py` subclasses are removed

The old file defined thin subclasses of `edm.TimeSeries` — `ElectricityDemand`, `ElectricitySupply`, `ElectricityAreaDemand`, `HeatingDemand`, etc. — whose only purpose was to add a `location` or `area` field to the pandas wrapper.

These are now obsolete because:

- **`location`** is a first-class per-column field on `TimeSeriesTable` (and on `TimeSeries`), so there is no need to subclass in order to carry geographic context.
- **`area`** (`GeoPolygon` / `GeoMultiPolygon`) belongs on the enclosing `EnergyAsset` subclass, not on the time series itself.
- **The semantic distinction** between demand, supply, production, and consumption is expressed through `timedatamodel.DataType` and `labels`:

  | Old class | New approach |
  |---|---|
  | `ElectricityDemand` / `ElectricityConsumption` | `DataType.ACTUAL` + `labels={"direction": "consumption"}` |
  | `ElectricitySupply` / `ElectricityProduction` | `DataType.ACTUAL` + `labels={"direction": "production"}` |
  | `ElectricityPrice` | `DataType.REFERENCE` + `labels={"carrier": "electricity"}` |
  | `CarbonIntensity` | `DataType.REFERENCE` + `labels={"signal": "carbon_intensity"}` |

  The migration guide with full examples is preserved in `timeseries.py`.

### Usage example

```python
import timedatamodel as tdm
import energydatamodel as edm

# Build a TimeSeriesTable from individual signals
table = tdm.TimeSeriesTable.from_timeseries(
    [ts_active_power, ts_wind_speed, ts_iec_state],
    frequency=tdm.Frequency.PT1H,
)

turbine = edm.WindTurbine(
    name="MUN-WTG001",
    capacity=2200.0,
    latitude=63.54,
    longitude=14.97,
    timeseries=table,
)

# Extract a single signal
active_power: tdm.TimeSeries = turbine.timeseries.select_column("ActivePower")

# Plot all signals
turbine.plot_timeseries()

# Plot a subset
turbine.plot_timeseries(columns=["ActivePower", "WindSpeed"])
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)