### PR TITLE
Restructure to Element/Node/Edge/Collection hierarchy with typed JSON round-trip

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,17 @@
 
 ## Class hierarchy
 
-Everything in EnergyDataModel inherits from a single root, `Entity`, which carries identity (`name`, `_id`), attached time-series descriptors, and an optional [shapely](https://shapely.readthedocs.io/) geometry. Two sibling subtrees specialize it:
+Everything in EnergyDataModel inherits from a single root, `Element`, which carries identity (`name`, `_id`), attached time-series descriptors, and an optional [shapely](https://shapely.readthedocs.io/) geometry. Three sibling subtrees specialize it, plus an `Asset` mixin:
 
-* **`Node`** — anything that exists as a thing (assets, areas, sensors, grid nodes, collections). Adds `members` and `tz`.
+* **`Node`** — graph vertices (equipment, areas, sensors, grid topology points). Adds `members` and `tz`.
 * **`Edge`** — relationships between two nodes (lines, transformers, interconnectors). Adds `from_entity`, `to_entity`, `directed`.
+* **`Collection`** — logical groupings (Portfolio, Site, ...). Adds `members` and `tz`. Not a graph vertex — `isinstance(portfolio, Node)` is False.
+* **`Asset`** — cross-cutting mixin marking physical equipment. Adds `commissioning_date`. Mixed into Node via `NodeAsset` and into Edge via `EdgeAsset`; never used as a leaf type.
 
 ```
-Entity  (name, _id, timeseries, geometry)
+Element  (name, _id, timeseries, geometry)
 ├── Node  (+ members, tz)
-│   ├── Asset                — physical energy equipment
+│   ├── NodeAsset            — Node × Asset (physical equipment vertices)
 │   │   WindTurbine, WindFarm, WindPowerArea, PVArray, PVSystem,
 │   │   SolarPowerArea, Battery, HeatPump, HydroPowerPlant,
 │   │   HydroTurbine, Reservoir, Building, House
@@ -58,20 +60,22 @@ Entity  (name, _id, timeseries, geometry)
 │   ├── Sensor               — measurement instruments
 │   │   TemperatureSensor, WindSpeedSensor, RadiationSensor,
 │   │   RainSensor, HumiditySensor
-│   ├── Area                 — administrative / market regions
-│   │   BiddingZone, Country, ControlArea, WeatherCell,
-│   │   SynchronousArea (+ nominal_frequency)
-│   └── Collection           — grouping / container marker
-│       Portfolio, Site, MultiSite, Region,
-│       EnergyCommunity, VirtualPowerPlant, SubNetwork, Network
-└── Edge  (+ from_entity, to_entity, directed)
-    Line, Link, Transformer, Pipe, Interconnection
+│   └── Area                 — administrative / market regions
+│       BiddingZone, Country, ControlArea, WeatherCell,
+│       SynchronousArea (+ nominal_frequency)
+├── Edge  (+ from_entity, to_entity, directed)
+│   └── EdgeAsset            — Edge × Asset (physical equipment edges)
+│       Line, Link, Transformer, Pipe, Interconnection
+├── Collection  (+ members, tz)    — logical grouping, not a vertex
+│   Portfolio, Site, MultiSite, Region,
+│   EnergyCommunity, VirtualPowerPlant, SubNetwork, Network
+└── Asset  (+ commissioning_date)  — mixin, never a leaf
 ```
 
 | Module         | Data Classes |
 | :----          | :----        |
-| 🧱&nbsp;`entity` / `node` / `edge` | `Entity`, `Node`, `Edge` |
-| 🏷️&nbsp;`bases` | `Asset`, `GridNode`, `Sensor` |
+| 🧱&nbsp;`element` / `node` / `edge` | `Element`, `Node`, `Edge` |
+| 🏷️&nbsp;`asset` / `bases` | `Asset`, `NodeAsset`, `GridNode`, `Sensor` |
 | 🗺️&nbsp;`geospatial` | `GeoLocation`, `GeoPolygon`, `GeoMultiPolygon` |
 | ☀️&nbsp;`solar` | `FixedMount`, `SingleAxisTrackerMount`, `PVArray`, `PVSystem`, `SolarPowerArea` |
 | 🌬️&nbsp;`wind` | `WindTurbine`, `WindFarm`, `WindPowerArea` |
@@ -80,7 +84,7 @@ Entity  (name, _id, timeseries, geometry)
 | ♻️&nbsp;`heatpump` | `HeatPump` |
 | 🏠&nbsp;`building` | `Building`, `House` |
 | 🌡️&nbsp;`weathersensor` | `TemperatureSensor`, `WindSpeedSensor`, `RadiationSensor`, `RainSensor`, `HumiditySensor` |
-| ⚡&nbsp;`powergrid` | `Carrier`, `JunctionPoint`, `Meter`, `DeliveryPoint`, `Line`, `Link`, `Transformer`, `Pipe`, `Interconnection`, `SubNetwork`, `Network` |
+| ⚡&nbsp;`powergrid` | `Carrier`, `EdgeAsset`, `JunctionPoint`, `Meter`, `DeliveryPoint`, `Line`, `Link`, `Transformer`, `Pipe`, `Interconnection`, `SubNetwork`, `Network` |
 | 🗺️&nbsp;`area` | `Area`, `BiddingZone`, `Country`, `ControlArea`, `WeatherCell`, `SynchronousArea` |
 | 📦&nbsp;`containers` | `Collection`, `Portfolio`, `Site`, `MultiSite`, `Region`, `EnergyCommunity`, `VirtualPowerPlant` |
 | 📈&nbsp;`constructors` | `electricity_supply`, `electricity_demand`, `electricity_supply_area`, `electricity_demand_area`, `spot_price`, `cross_border_flow`, `grid_frequency`, `temperature`, `gas_supply`, `gas_demand`, `heating_demand` |

--- a/docs/energydatamodel/base.rst
+++ b/docs/energydatamodel/base.rst
@@ -1,10 +1,10 @@
 Core hierarchy
 =======================
 
-Entity
-------
+Element
+-------
 
-.. automodule:: energydatamodel.entity
+.. automodule:: energydatamodel.element
    :members:
    :undoc-members:
    :show-inheritance:
@@ -25,8 +25,21 @@ Edge
    :undoc-members:
    :show-inheritance:
 
-Bases (Asset, GridNode, Sensor)
--------------------------------
+Collection
+----------
+
+.. automodule:: energydatamodel.containers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Asset, NodeAsset, GridNode, Sensor
+----------------------------------
+
+.. automodule:: energydatamodel.asset
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 .. automodule:: energydatamodel.bases
    :members:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -2,30 +2,48 @@
 Quickstart Guide
 ===================
 
-This quickstart guide will help you get started with the EnergyDataModel library, covering the basic installation process and a simple usage example.
+This quickstart guide walks you through installing EnergyDataModel and
+assembling a small energy-system tree end-to-end.
 
 Installation
 ------------
 
-EnergyDataModel can be easily installed using pip:
+EnergyDataModel can be installed from PyPI:
 
 .. code-block:: bash
 
    pip install energydatamodel
 
-Ensure you have Python 3.6 or later installed on your system.
+Python 3.12 or later is required.
 
-Basic Usage
+Basic usage
 -----------
 
-After installing the library, you can start using it to model and analyze energy data:
+Every structural class inherits from a single ``Element`` root. Nodes
+(``WindTurbine``, ``Battery``, ...), edges (``Interconnection``, ``Line``),
+and collections (``Site``, ``Portfolio``) all compose into a tree you can
+serialize to JSON and reload losslessly.
 
 .. code-block:: python
 
-   from energydatamodel import Location, Meter
+   import energydatamodel as edm
+   from shapely.geometry import Point
 
-   # Example usage
-   my_location = Location(latitude=50.0, longitude=-0.1257)
-   print(my_location)
+   pvsystem = edm.PVSystem(name="PV-1", capacity=2400, surface_azimuth=180, surface_tilt=25)
+   windturbine = edm.WindTurbine(name="WT-1", capacity=3200, hub_height=120, rotor_diameter=100)
+   battery = edm.Battery(name="B-1", storage_capacity=1000, max_charge=500, max_discharge=500)
 
-Further steps and more complex examples can be found in the 'Examples' section.
+   site = edm.Site(
+       name="Site-1",
+       geometry=Point(12.8, 55.5),  # (lon, lat)
+       members=[pvsystem, windturbine, battery],
+   )
+
+   portfolio = edm.Portfolio(name="My Portfolio", members=[site])
+
+   js = portfolio.to_json()
+   restored = edm.Portfolio.from_json(js)
+
+See the :doc:`examples` page and the ``examples/quickstart.ipynb`` notebook
+for a full walkthrough including time-series descriptors, areas, edges,
+cross-tree references, and geometry round-trip.

--- a/energydatamodel/__init__.py
+++ b/energydatamodel/__init__.py
@@ -1,4 +1,4 @@
-"""energydatamodel — unified Entity/Node/Edge hierarchy for energy assets & structures."""
+"""energydatamodel — unified Element/Node/Edge hierarchy for energy assets & structures."""
 
 from timedatamodel import (
     DataShape,
@@ -11,11 +11,12 @@ from timedatamodel import (
 from timedatamodel import GeoLocation as TDMGeoLocation
 
 # Core
-from .entity import Entity
+from .element import Element
+from .asset import Asset
 from .node import Node
 from .edge import Edge
 from .reference import Reference, UnresolvedReferenceError
-from .bases import Asset, GridNode, Sensor
+from .bases import GridNode, NodeAsset, Sensor
 
 # Geospatial
 from .geospatial import (
@@ -50,6 +51,7 @@ from .wind import WindFarm, WindPowerArea, WindTurbine
 from .powergrid import (
     Carrier,
     DeliveryPoint,
+    EdgeAsset,
     Interconnection,
     JunctionPoint,
     Line,
@@ -71,7 +73,7 @@ from .area import (
     WeatherCell,
 )
 
-# Containers (Collection marker + subclasses)
+# Containers (Collection + subclasses)
 from .containers import (
     Collection,
     EnergyCommunity,
@@ -100,19 +102,19 @@ from .quantities import Kind, Quantity, Scope, build_metric
 
 # JSON IO
 from .json_io import (
-    entity_from_json,
-    entity_to_json,
+    element_from_json,
+    element_to_json,
     from_json_str,
-    register_builtin_entities,
-    register_entity,
+    register_builtin_elements,
+    register_element,
     register_value_type,
     to_json_str,
 )
 
-# Auto-register every Entity subclass imported above for JSON dispatch.
-register_builtin_entities()
+# Auto-register every Element subclass imported above for JSON dispatch.
+register_builtin_elements()
 
-# Register non-Entity value dataclasses for JSON dispatch.
+# Register non-Element value dataclasses for JSON dispatch.
 for _cls in (GeoLocation, GeoMultiPolygon, Carrier):
     register_value_type(_cls)
 del _cls

--- a/energydatamodel/area.py
+++ b/energydatamodel/area.py
@@ -11,7 +11,7 @@ constructor functions). Type discrimination is via ``isinstance``.
   Carries an extra ``nominal_frequency`` field (50 Hz in Europe / Nordic /
   GB / Ireland / Baltic / IPS-UPS; 60 Hz in North America).
 
-The geometry (Polygon / MultiPolygon) lives on :class:`Entity` and is
+The geometry (Polygon / MultiPolygon) lives on :class:`Element` and is
 inherited; areas without a known polygon simply leave it ``None``.
 """
 

--- a/energydatamodel/asset.py
+++ b/energydatamodel/asset.py
@@ -1,0 +1,37 @@
+"""Asset — mixin marking physical energy equipment.
+
+``Asset`` is the umbrella for anything the energy domain treats as a physical,
+commissioned piece of equipment: wind turbines, batteries, heat pumps, sensors,
+meters, power lines, transformers, pipes. It is a pure mixin — never
+instantiated directly and never used as a leaf type. Concrete equipment
+classes inherit from ``Asset`` together with either :class:`Node` or
+:class:`Edge` via the :class:`NodeAsset` / :class:`EdgeAsset` intermediates in
+:mod:`energydatamodel.bases` and :mod:`energydatamodel.powergrid`.
+
+``isinstance(x, Asset)`` answers "is this a piece of physical equipment?"
+uniformly across node- and edge-shaped classes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import ClassVar, Optional
+
+from energydatamodel.element import Element
+
+
+@dataclass(repr=False, kw_only=True)
+class Asset(Element):
+    """Marker mixin for physical energy equipment.
+
+    Carries fields genuinely shared across every piece of equipment —
+    independent of whether the equipment is shaped like a graph vertex
+    (``WindTurbine``) or a graph edge (``Line``).
+    """
+
+    commissioning_date: Optional[date] = None
+
+    _BASE_FIELDS: ClassVar[frozenset] = Element._BASE_FIELDS | frozenset({
+        "commissioning_date",
+    })

--- a/energydatamodel/bases.py
+++ b/energydatamodel/bases.py
@@ -1,19 +1,14 @@
-"""Semantic intermediates under :class:`Node`.
+"""Node-side equipment intermediates.
 
-These three subclasses don't add fields beyond what ``Node`` already gives
-them (geometry inherited via ``Entity``, members + tz inherited from
-``Node``); they exist as semantic markers so callers can write
-``isinstance(x, Asset)`` / ``isinstance(x, GridNode)`` / ``isinstance(x, Sensor)``
-to discriminate roles cleanly.
-
-* :class:`Asset` — physical energy equipment (generates, consumes, or stores
-  energy). Subclassed by WindTurbine, PVSystem, Battery, HeatPump,
-  HydroPowerPlant, Building, House, etc.
-* :class:`GridNode` — topological point in an electrical/grid network (a bus,
-  a meter, a delivery point). Adds ``carrier``.
-* :class:`Sensor` — measurement instrument. No added fields on the base;
-  concrete sensor subclasses (TemperatureSensor, WindSpeedSensor, ...) carry
-  installation-specific fields like ``height``.
+* :class:`NodeAsset` — mixes ``Node`` and ``Asset``. The single mixin point on
+  the node side; everything physical and vertex-shaped lives below it with
+  plain single inheritance. Subclassed directly by WindTurbine, Battery,
+  HeatPump, etc.; and further by :class:`Sensor` and :class:`GridNode` for
+  their role-specific fields.
+* :class:`Sensor` — measurement instruments. Adds ``height`` (shared by every
+  concrete sensor in the weather-sensor family).
+* :class:`GridNode` — topological points in an electrical / grid network
+  (bus, meter, delivery point). Adds ``carrier``.
 """
 
 from __future__ import annotations
@@ -21,6 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar, Optional
 
+from energydatamodel.asset import Asset
 from energydatamodel.node import Node
 
 if TYPE_CHECKING:
@@ -28,48 +24,54 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------
-# Asset — base for physical energy equipment
+# NodeAsset — the single (Node, Asset) mixin point
 # ---------------------------------------------------------------------
 
 
 @dataclass(repr=False, kw_only=True)
-class Asset(Node):
-    """Physical energy equipment that generates, consumes, or stores energy.
+class NodeAsset(Node, Asset):
+    """Mixin intermediate: a ``Node`` that is also an ``Asset``.
 
-    Subclasses (``WindTurbine``, ``Battery``, ``HeatPump``, ...) add their own
-    domain fields. The docstring lives here; leaf classes carry only domain
-    fields.
+    Concrete equipment classes (``WindTurbine``, ``Battery``, ``HeatPump``, ...)
+    and the role-specific intermediates :class:`Sensor` and :class:`GridNode`
+    all inherit from here. Single inheritance below this point.
     """
 
+    _BASE_FIELDS: ClassVar[frozenset] = Node._BASE_FIELDS | Asset._BASE_FIELDS
+
 
 # ---------------------------------------------------------------------
-# GridNode — topological point in an electrical / grid network
+# Sensor — measurement instruments
 # ---------------------------------------------------------------------
 
 
 @dataclass(repr=False, kw_only=True)
-class GridNode(Node):
+class Sensor(NodeAsset):
+    """A measurement instrument that observes an environmental variable.
+
+    Concrete sensor subclasses (``TemperatureSensor``, ``WindSpeedSensor``, …)
+    inherit ``height`` from here and add no new fields.
+    """
+
+    height: Optional[float] = None
+
+    _BASE_FIELDS: ClassVar[frozenset] = NodeAsset._BASE_FIELDS | frozenset({"height"})
+
+
+# ---------------------------------------------------------------------
+# GridNode — topological point in a grid
+# ---------------------------------------------------------------------
+
+
+@dataclass(repr=False, kw_only=True)
+class GridNode(NodeAsset):
     """A topological point in a grid network — a bus, meter, or delivery point.
 
-    Distinct from :class:`Asset`: GridNodes don't generate or consume energy
-    themselves; they're abstract points where other things connect.
+    GridNodes are equipment too (they have manufacturers, commissioning dates,
+    etc. via :class:`Asset`). They're distinguished from generation/consumption
+    assets by carrying a ``carrier``.
     """
 
     carrier: Optional["Carrier"] = None
 
-    _BASE_FIELDS: ClassVar[frozenset] = Node._BASE_FIELDS | frozenset({"carrier"})
-
-
-# ---------------------------------------------------------------------
-# Sensor — measurement instrument
-# ---------------------------------------------------------------------
-
-
-@dataclass(repr=False, kw_only=True)
-class Sensor(Node):
-    """A measurement instrument that observes an environmental variable.
-
-    No fields on the base; concrete sensor subclasses (``TemperatureSensor``,
-    ``WindSpeedSensor``, etc.) carry installation-specific fields like
-    ``height``.
-    """
+    _BASE_FIELDS: ClassVar[frozenset] = NodeAsset._BASE_FIELDS | frozenset({"carrier"})

--- a/energydatamodel/battery.py
+++ b/energydatamodel/battery.py
@@ -3,11 +3,11 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from energydatamodel.bases import Asset
+from energydatamodel.bases import NodeAsset
 
 
 @dataclass(repr=False, kw_only=True)
-class Battery(Asset):
+class Battery(NodeAsset):
     storage_capacity: Optional[float] = None
     min_soc: Optional[float] = None
     max_charge: Optional[float] = None

--- a/energydatamodel/building.py
+++ b/energydatamodel/building.py
@@ -6,19 +6,19 @@ from dataclasses import dataclass
 from typing import Optional
 
 
-from energydatamodel.bases import Asset
+from energydatamodel.bases import NodeAsset
 
 
 @dataclass(repr=False, kw_only=True)
-class Building(Asset):
-    """A building. An :class:`Asset` (location, capacity-like fields) that also
-    contains child Entities via the inherited ``members`` list."""
+class Building(NodeAsset):
+    """A building. A physical asset that also contains child Elements via the
+    inherited ``members`` list."""
 
     type: Optional[str] = None
 
 
 @dataclass(repr=False, kw_only=True)
-class House(Asset):
+class House(NodeAsset):
     """A house. Same structure as :class:`Building` with a few convenience
     accessors."""
 

--- a/energydatamodel/containers.py
+++ b/energydatamodel/containers.py
@@ -1,12 +1,13 @@
 """Collection marker and container subclasses.
 
-:class:`Collection` is a :class:`Node` whose primary purpose is grouping
-other entities. It adds no fields — it exists as a semantic marker for
-``isinstance(x, Collection)`` checks and UI/API grouping.
+:class:`Collection` is an :class:`Element` whose primary purpose is grouping
+other elements. It is **not** a :class:`Node` — collections aren't graph
+vertices; they're organizational/logical groupings. Collection shares the
+``members`` and ``tz`` field shape with Node, but the semantics differ —
+``isinstance(x, Node)`` on a Portfolio should return False.
 
-Concrete subclasses carry no additional fields either; they distinguish
-a Portfolio from a Site at the type level for serialization / introspection
-/ UI.
+Concrete subclasses carry no additional fields; they distinguish a Portfolio
+from a Site at the type level for serialization / introspection / UI.
 
 Conventions:
 
@@ -22,14 +23,40 @@ Conventions:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import datetime
+from dataclasses import dataclass, field
+from typing import ClassVar, List, Optional
 
-from energydatamodel.node import Node
+from energydatamodel.element import Element
 
 
 @dataclass(repr=False, kw_only=True)
-class Collection(Node):
-    """Marker for entities whose primary purpose is grouping other entities."""
+class Collection(Element):
+    """An Element whose primary purpose is grouping other Elements.
+
+    Not a :class:`Node` — collections are organizational groupings, not graph
+    vertices. Carries ``members`` and ``tz`` (same shape as Node, different
+    semantics).
+    """
+
+    members: List[Element] = field(default_factory=list)
+    tz: Optional[datetime.tzinfo] = None
+
+    _BASE_FIELDS: ClassVar[frozenset] = Element._BASE_FIELDS | frozenset({
+        "members", "tz",
+    })
+    _CHILDREN_FIELDS: ClassVar[frozenset] = frozenset({"members"})
+
+    def children(self) -> list:
+        return list(self.members)
+
+    def add_child(self, obj: Element) -> None:
+        if not isinstance(obj, Element):
+            raise TypeError(
+                f"{type(self).__name__} only accepts Element children, "
+                f"got {type(obj).__name__}"
+            )
+        self.members.append(obj)
 
 
 @dataclass(repr=False, kw_only=True)

--- a/energydatamodel/edge.py
+++ b/energydatamodel/edge.py
@@ -1,26 +1,30 @@
 """Edge — the "relationship" subtree of EDM.
 
-An ``Edge`` is an edge between two :class:`Node` instances: a line
-between two buses, an interconnector between two bidding zones, a transformer
-between two buses, a pipe between two delivery points. Edges sit
-sibling to ``Node`` under :class:`Entity`, not under ``Node`` — this
-keeps ``members`` and ``tz`` off Edges, where they don't apply.
+An ``Edge`` is an edge between two :class:`Node` instances: a line between
+two buses, an interconnector between two bidding zones, a transformer
+between two buses, a pipe between two delivery points. Edges sit sibling to
+``Node`` under :class:`Element`, not under ``Node`` — this keeps ``members``
+and ``tz`` off Edges, where they don't apply.
 
-Concrete subclasses (Line, Link, Transformer, Pipe, Interconnection) live in
-:mod:`energydatamodel.powergrid`.
+Concrete edge-equipment subclasses (Line, Link, Transformer, Pipe,
+Interconnection) live in :mod:`energydatamodel.powergrid` under
+:class:`EdgeAsset`.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional
 
-from energydatamodel.entity import Entity
+from energydatamodel.element import Element
 from energydatamodel.reference import Reference
+
+if TYPE_CHECKING:
+    from energydatamodel.node import Node
 
 
 @dataclass(repr=False, kw_only=True)
-class Edge(Entity):
+class Edge(Element):
     """An edge between two Nodes.
 
     Edges are **always directed by convention** — flow in the opposite
@@ -28,10 +32,10 @@ class Edge(Entity):
     flag is kept for explicit cases (e.g. pure bidirectional pipes).
     """
 
-    from_entity: Optional[Reference] = None
-    to_entity: Optional[Reference] = None
+    from_entity: Optional[Reference["Node"]] = None
+    to_entity: Optional[Reference["Node"]] = None
     directed: bool = True
 
-    _BASE_FIELDS: ClassVar[frozenset] = Entity._BASE_FIELDS | frozenset({
+    _BASE_FIELDS: ClassVar[frozenset] = Element._BASE_FIELDS | frozenset({
         "from_entity", "to_entity", "directed",
     })

--- a/energydatamodel/element.py
+++ b/energydatamodel/element.py
@@ -1,23 +1,27 @@
-"""Entity — the root of the EDM type hierarchy.
+"""Element — the root of the EDM type hierarchy.
 
-``Entity`` is the shared base for everything in the model. It carries the
+``Element`` is the shared base for everything in the model. It carries the
 fields that any persistable, named, geometry-bearing object needs:
 
 * ``name``, ``_id`` — identity
 * ``timeseries`` — descriptors of attached time series
 * ``geometry`` — optional shapely geometry (Point, Polygon, LineString, ...)
 
-Two sibling subtrees specialize ``Entity``:
+Sibling subtrees specialize ``Element``:
 
 * :class:`Node` (in :mod:`energydatamodel.node`) — anything that exists
-  as a "thing": Assets, Areas, GridNodes, Sensors, plus container markers
-  like Portfolio/Site/Region. Adds ``members`` and ``tz``.
+  as a "thing": graph vertices, Areas, plus container markers.
+  Adds ``members`` and ``tz``.
 * :class:`Edge` (in :mod:`energydatamodel.edge`) — edges between
   two Nodes. Adds ``from_entity``, ``to_entity``, ``directed``.
+* :class:`Asset` (in :mod:`energydatamodel.asset`) — mixin marking
+  physical energy equipment. Mixed with ``Node`` or ``Edge`` via
+  :class:`NodeAsset` / :class:`EdgeAsset`.
+* :class:`Collection` (in :mod:`energydatamodel.containers`) — groupings
+  that aren't graph vertices (Portfolio, Site, Region, ...).
 
-``Entity`` is abstract in spirit (never instantiated directly) but is a
-concrete dataclass so subclasses can ``super().__init__(...)`` cleanly. Users
-should reach for ``Node`` or ``Edge`` (or a concrete subclass).
+``Element`` is abstract in spirit (never instantiated directly) but is a
+concrete dataclass so subclasses can ``super().__init__(...)`` cleanly.
 """
 
 from __future__ import annotations
@@ -35,7 +39,7 @@ from timedatamodel import TimeSeriesDescriptor
 
 
 def _tree_repr(obj, prefix: str = "", is_last: bool = True, is_root: bool = True) -> str:
-    """Render a tree representation of an Entity hierarchy via ``.children()``."""
+    """Render a tree representation of an Element hierarchy via ``.children()``."""
     name = getattr(obj, "name", None)
     label = f"{type(obj).__name__}('{name}')" if name else f"{type(obj).__name__}()"
     connector = "" if is_root else ("\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 ")
@@ -48,12 +52,12 @@ def _tree_repr(obj, prefix: str = "", is_last: bool = True, is_root: bool = True
 
 
 @dataclass(repr=False, kw_only=True)
-class Entity:
+class Element:
     """Common base for every persistable object in EDM.
 
-    Carries the fields shared by both Nodes (things) and Edges
-    (relationships): name, id, attached time-series descriptors, and an
-    optional shapely geometry.
+    Carries the fields shared by Nodes, Edges, Assets and Collections:
+    name, id, attached time-series descriptors, and an optional shapely
+    geometry.
     """
 
     name: Optional[str] = None
@@ -93,7 +97,7 @@ class Entity:
 
     # ------------------------------------------------------------------ tree
     def children(self) -> list:
-        """Child entities for tree walking. Override in subclasses with children."""
+        """Child elements for tree walking. Override in subclasses with children."""
         return []
 
     def add_child(self, obj) -> None:
@@ -106,8 +110,8 @@ class Entity:
     def to_tree(self) -> str:
         """Return the hierarchy rendered as an indented tree string.
 
-        Use ``print(entity.to_tree())`` to display it. In a notebook, printing
-        the entity directly (``entity``) also renders the tree via ``__repr__``.
+        Use ``print(element.to_tree())`` to display it. In a notebook, printing
+        the element directly (``element``) also renders the tree via ``__repr__``.
         """
         return _tree_repr(self)
 
@@ -131,14 +135,14 @@ class Entity:
     # --------------------------------------------------------------- json
     def to_json(self, include_ids: bool = False) -> dict:
         """Serialize to a JSON-compatible dict. Full implementation in ``json_io``."""
-        from energydatamodel.json_io import entity_to_json
-        return entity_to_json(self, include_ids=include_ids)
+        from energydatamodel.json_io import element_to_json
+        return element_to_json(self, include_ids=include_ids)
 
     @classmethod
-    def from_json(cls, data: dict) -> "Entity":
+    def from_json(cls, data: dict) -> "Element":
         """Deserialize from a JSON-compatible dict. Full implementation in ``json_io``."""
-        from energydatamodel.json_io import entity_from_json
-        return entity_from_json(data, expected_type=cls)
+        from energydatamodel.json_io import element_from_json
+        return element_from_json(data, expected_type=cls)
 
     # ------------------------------------------------------------- geojson
     def geometry_to_geojson(self, geometry):
@@ -157,7 +161,7 @@ class Entity:
         return {"type": "FeatureCollection", "features": features}
 
     def _collect_geojson_features(self, exclude_none: bool = True):
-        """Yield flat Feature dicts from this entity and its descendants."""
+        """Yield flat Feature dicts from this element and its descendants."""
         children = self.children()
         if children:
             for child in children:

--- a/energydatamodel/geospatial.py
+++ b/energydatamodel/geospatial.py
@@ -1,20 +1,21 @@
 """Geospatial helper types.
 
-These are value types (not :class:`Entity` subclasses) — they carry
+These are value types (not :class:`Element` subclasses) — they carry
 coordinates and geometry only, and can be used as inputs that get converted
-into shapely geometries on Entity. Shapely is the underlying truth for all
-geometry storage on Entity.
+into shapely geometries on Element. Shapely is the underlying truth for all
+geometry storage on Element.
 """
 
 from __future__ import annotations
 
+import datetime
 import json
 from dataclasses import dataclass
 from typing import Optional, Union
+from zoneinfo import ZoneInfo
 
 import geopandas as gpd
 import pvlib
-import pytz
 from shapely.geometry import MultiPolygon, Point, Polygon
 
 
@@ -23,19 +24,19 @@ class GeoLocation:
     """Point location with a timezone and optional altitude.
 
     Convenience input value type. Convert to a shapely ``Point`` via
-    :meth:`to_point` when populating an Entity's ``geometry`` field.
+    :meth:`to_point` when populating an Element's ``geometry`` field.
     """
 
     longitude: float
     latitude: float
-    tz: Union[str, pytz.BaseTzInfo] = "UTC"
+    tz: Union[str, datetime.tzinfo] = "UTC"
     altitude: Optional[float] = None
     name: Optional[str] = None
 
     def __post_init__(self):
         self.point = Point(self.longitude, self.latitude)
         if isinstance(self.tz, str):
-            self.tz = pytz.timezone(self.tz)
+            self.tz = ZoneInfo(self.tz)
 
     @classmethod
     def from_point(cls, point: Point):
@@ -51,7 +52,7 @@ class GeoLocation:
     def to_point(self) -> Point:
         """Return a shapely ``Point`` using ``(longitude, latitude)`` ordering.
 
-        Use this to populate an Entity's ``geometry`` field from a
+        Use this to populate an Element's ``geometry`` field from a
         ``GeoLocation`` input.
         """
         return Point(self.longitude, self.latitude)

--- a/energydatamodel/heatpump.py
+++ b/energydatamodel/heatpump.py
@@ -3,11 +3,11 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from energydatamodel.bases import Asset
+from energydatamodel.bases import NodeAsset
 
 
 @dataclass(repr=False, kw_only=True)
-class HeatPump(Asset):
+class HeatPump(NodeAsset):
     """A heat pump in an energy system."""
 
     capacity: Optional[float] = None  #: heating/cooling capacity in kW.

--- a/energydatamodel/hydro.py
+++ b/energydatamodel/hydro.py
@@ -5,11 +5,11 @@ from typing import Optional, Union
 
 import pandas as pd
 
-from energydatamodel.bases import Asset
+from energydatamodel.bases import NodeAsset
 
 
 @dataclass(repr=False, kw_only=True)
-class Reservoir(Asset):
+class Reservoir(NodeAsset):
     """Reservoir used in a hydroelectric power plant for storing water."""
 
     capacity: Optional[float] = None  #: Water capacity in cubic meters.
@@ -18,17 +18,16 @@ class Reservoir(Asset):
 
 
 @dataclass(repr=False, kw_only=True)
-class HydroTurbine(Asset):
+class HydroTurbine(NodeAsset):
     """Individual hydro turbine in a hydroelectric plant."""
 
     turbine_type: Optional[str] = None  #: e.g. Francis, Kaplan.
     capacity: Optional[float] = None  #: Max power output in MW.
     efficiency: Optional[float] = None  #: Efficiency percentage.
-    operational_since: Optional[int] = None
 
 
 @dataclass(repr=False, kw_only=True)
-class HydroPowerPlant(Asset):
+class HydroPowerPlant(NodeAsset):
     """Hydro power plant."""
 
     capacity: Optional[float] = None  #: in MW.
@@ -36,6 +35,5 @@ class HydroPowerPlant(Asset):
     annual_output: Optional[float] = None  #: annual energy output in MWh.
     turbine_type: Optional[str] = None
     reservoir_capacity: Optional[float] = None
-    operational_since: Optional[int] = None
     environmental_impact: Optional[str] = None
     maintenance_schedule: Optional[Union[pd.DataFrame, dict]] = None

--- a/energydatamodel/json_io.py
+++ b/energydatamodel/json_io.py
@@ -1,10 +1,10 @@
-"""JSON serialization for Entity trees.
+"""JSON serialization for Element trees.
 
-Wire format: each entity → ``{"type": "ClassName", ...fields}``. Lists of
-Entities become nested arrays of such dicts. ``Reference`` fields become path
+Wire format: each element → ``{"type": "ClassName", ...fields}``. Lists of
+Elements become nested arrays of such dicts. ``Reference`` fields become path
 strings. Enums become their string values. Dataclass value types (e.g.
 ``Location``, ``Carrier``) are serialized as nested dicts without a ``type``
-tag (they're not Entity subclasses and are round-tripped by field-type
+tag (they're not Element subclasses and are round-tripped by field-type
 inspection on the receiving side).
 
 ``from_json`` is a two-pass walk:
@@ -19,14 +19,17 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import json as json_module
+import typing
 from enum import Enum
+from functools import lru_cache
 from typing import Any, Dict, List, Optional, Type, get_args, get_origin
+from zoneinfo import ZoneInfo
 
 from shapely.geometry import mapping, shape
 from shapely.geometry.base import BaseGeometry
 from timedatamodel import DataType, Frequency, TimeSeriesDescriptor, TimeSeriesType
 
-from energydatamodel.entity import Entity
+from energydatamodel.element import Element
 from energydatamodel.reference import Reference, UnresolvedReferenceError
 
 
@@ -35,16 +38,16 @@ from energydatamodel.reference import Reference, UnresolvedReferenceError
 # ---------------------------------------------------------------------
 
 
-_REGISTRY: Dict[str, Type[Entity]] = {}
+_REGISTRY: Dict[str, Type[Element]] = {}
 _VALUE_REGISTRY: Dict[str, type] = {}
 
 
-def register_entity(cls: Type[Entity]) -> Type[Entity]:
-    """Register an Entity subclass under its class name for JSON dispatch."""
+def register_element(cls: Type[Element]) -> Type[Element]:
+    """Register an Element subclass under its class name for JSON dispatch."""
     name = cls.__name__
     if name in _REGISTRY and _REGISTRY[name] is not cls:
         raise ValueError(
-            f"register_entity: duplicate name {name!r} "
+            f"register_element: duplicate name {name!r} "
             f"(existing={_REGISTRY[name]!r}, new={cls!r})"
         )
     _REGISTRY[name] = cls
@@ -52,11 +55,11 @@ def register_entity(cls: Type[Entity]) -> Type[Entity]:
 
 
 def register_value_type(cls: type) -> type:
-    """Register a non-Entity value dataclass (Location, Carrier, ...) for JSON dispatch.
+    """Register a non-Element value dataclass (Location, Carrier, ...) for JSON dispatch.
 
     Value types carry a ``__type__`` tag on the wire and are instantiated by
-    class-name lookup on load. Analogous to ``register_entity`` but without the
-    Entity inheritance requirement.
+    class-name lookup on load. Analogous to ``register_element`` but without the
+    Element inheritance requirement.
     """
     name = cls.__name__
     if name in _VALUE_REGISTRY and _VALUE_REGISTRY[name] is not cls:
@@ -68,30 +71,34 @@ def register_value_type(cls: type) -> type:
     return cls
 
 
-def get_registry() -> Dict[str, Type[Entity]]:
+def get_registry() -> Dict[str, Type[Element]]:
     return dict(_REGISTRY)
 
 
 # ---------------------------------------------------------------------
-# Serialization (Entity → dict)
+# Serialization (Element → dict)
 # ---------------------------------------------------------------------
 
 
-def _serialize_value(value: Any, *, include_ids: bool, root: Entity) -> Any:
+def _serialize_value(value: Any, *, include_ids: bool, root: Element) -> Any:
     if value is None:
         return None
-    if isinstance(value, Entity):
-        return _entity_to_dict(value, include_ids=include_ids, root=root)
+    if isinstance(value, Element):
+        return _element_to_dict(value, include_ids=include_ids, root=root)
     if isinstance(value, Reference):
         # Always emit the canonical full path from ``root``, regardless of whether
-        # the Reference's internal target is still a string or a resolved Entity.
+        # the Reference's internal target is still a string or a resolved Element.
         # ``Reference.path`` raises ``UnresolvedReferenceError`` if unreachable.
         return {"__ref__": value.path(root)}
     if isinstance(value, Enum):
         return value.value
+    if isinstance(value, datetime.datetime):
+        return value.isoformat()
+    if isinstance(value, datetime.date):
+        return value.isoformat()
     if isinstance(value, datetime.tzinfo):
-        # pytz timezones expose ``zone``; stdlib zoneinfo uses ``key``. Fall back to str().
-        return getattr(value, "zone", None) or getattr(value, "key", None) or str(value)
+        name = getattr(value, "key", None) or str(value)
+        return {"__tz__": name}
     if isinstance(value, BaseGeometry):
         # Shapely geometry → GeoJSON dict tagged with ``__geometry__`` for dispatch on load.
         return {"__geometry__": True, **mapping(value)}
@@ -122,7 +129,7 @@ def _descriptor_to_dict(desc: TimeSeriesDescriptor) -> dict:
     return out
 
 
-def _plain_dataclass_to_dict(obj, *, include_ids: bool, root: Entity) -> dict:
+def _plain_dataclass_to_dict(obj, *, include_ids: bool, root: Element) -> dict:
     out: dict = {"__type__": type(obj).__name__}
     for f in dataclasses.fields(obj):
         v = getattr(obj, f.name)
@@ -130,13 +137,13 @@ def _plain_dataclass_to_dict(obj, *, include_ids: bool, root: Entity) -> dict:
     return out
 
 
-def _entity_to_dict(entity: Entity, *, include_ids: bool, root: Entity) -> dict:
-    out: dict = {"type": type(entity).__name__}
-    for f in dataclasses.fields(entity):
+def _element_to_dict(element: Element, *, include_ids: bool, root: Element) -> dict:
+    out: dict = {"type": type(element).__name__}
+    for f in dataclasses.fields(element):
         name = f.name
         if name == "_id" and not include_ids:
             continue
-        value = getattr(entity, name)
+        value = getattr(element, name)
         if value is None:
             continue
         if isinstance(value, list) and not value:
@@ -145,34 +152,34 @@ def _entity_to_dict(entity: Entity, *, include_ids: bool, root: Entity) -> dict:
     return out
 
 
-def entity_to_json(entity: Entity, *, include_ids: bool = False) -> dict:
-    """Public: serialize an Entity (and its subtree) to a JSON-compatible dict.
+def element_to_json(element: Element, *, include_ids: bool = False) -> dict:
+    """Public: serialize an Element (and its subtree) to a JSON-compatible dict.
 
-    Resolved ``Reference`` fields are emitted as full paths from ``entity``
+    Resolved ``Reference`` fields are emitted as full paths from ``element``
     (the serialization root), so same-name collisions in different branches
     round-trip deterministically. Raises ``UnresolvedReferenceError`` if a
-    resolved reference points outside ``entity``'s subtree.
+    resolved reference points outside ``element``'s subtree.
     """
-    return _entity_to_dict(entity, include_ids=include_ids, root=entity)
+    return _element_to_dict(element, include_ids=include_ids, root=element)
 
 
-def to_json_str(entity: Entity, *, include_ids: bool = False, indent: Optional[int] = None) -> str:
+def to_json_str(element: Element, *, include_ids: bool = False, indent: Optional[int] = None) -> str:
     """Convenience: return a JSON string instead of a dict."""
-    return json_module.dumps(entity_to_json(entity, include_ids=include_ids), indent=indent)
+    return json_module.dumps(element_to_json(element, include_ids=include_ids), indent=indent)
 
 
 # ---------------------------------------------------------------------
-# Deserialization (dict → Entity)
+# Deserialization (dict → Element)
 # ---------------------------------------------------------------------
 
 
-def entity_from_json(data: dict, *, expected_type: Optional[Type[Entity]] = None) -> Entity:
-    """Public: deserialize a JSON-compatible dict into an Entity tree.
+def element_from_json(data: dict, *, expected_type: Optional[Type[Element]] = None) -> Element:
+    """Public: deserialize a JSON-compatible dict into an Element tree.
 
     Performs the two-pass walk (instantiate + resolve references).
     """
     root = _instantiate(data)
-    if expected_type is not None and expected_type is not Entity:
+    if expected_type is not None and expected_type is not Element:
         if not isinstance(root, expected_type):
             raise TypeError(
                 f"Expected {expected_type.__name__}, got {type(root).__name__}"
@@ -181,8 +188,8 @@ def entity_from_json(data: dict, *, expected_type: Optional[Type[Entity]] = None
     return root
 
 
-def from_json_str(text: str, *, expected_type: Optional[Type[Entity]] = None) -> Entity:
-    return entity_from_json(json_module.loads(text), expected_type=expected_type)
+def from_json_str(text: str, *, expected_type: Optional[Type[Element]] = None) -> Element:
+    return element_from_json(json_module.loads(text), expected_type=expected_type)
 
 
 # ----- pass 1: instantiate -----
@@ -203,13 +210,15 @@ def _instantiate(data: Any) -> Any:
         cls = _VALUE_REGISTRY[data["__type__"]]
         kwargs = {k: _instantiate(v) for k, v in data.items() if k != "__type__"}
         return cls(**kwargs)
+    if isinstance(data, dict) and "__tz__" in data:
+        return ZoneInfo(data["__tz__"])
     if isinstance(data, dict) and "__ref__" in data:
         return Reference(data["__ref__"])
     if isinstance(data, dict) and "type" in data:
         type_name = data["type"]
         if type_name not in _REGISTRY:
             raise ValueError(
-                f"Unknown Entity type {type_name!r}. Known types: {sorted(_REGISTRY)}"
+                f"Unknown Element type {type_name!r}. Known types: {sorted(_REGISTRY)}"
             )
         cls = _REGISTRY[type_name]
         kwargs = _build_kwargs(cls, data)
@@ -219,16 +228,28 @@ def _instantiate(data: Any) -> Any:
     return data
 
 
-def _build_kwargs(cls: Type[Entity], data: dict) -> dict:
+@lru_cache(maxsize=None)
+def _resolved_type_hints(cls: type) -> Dict[str, Any]:
+    """Resolve string annotations on a dataclass to concrete types (once per class)."""
+    try:
+        return typing.get_type_hints(cls)
+    except Exception:
+        return {}
+
+
+def _build_kwargs(cls: Type[Element], data: dict) -> dict:
     kwargs: dict = {}
     field_map = {f.name: f for f in dataclasses.fields(cls)}
+    hints = _resolved_type_hints(cls)
     for key, raw in data.items():
         if key == "type":
             continue
         if key not in field_map:
             continue  # unknown field — ignore (forward-compat)
         f = field_map[key]
-        kwargs[key] = _instantiate_for_field(f.type, raw)
+        # Prefer resolved type hint (handles ``from __future__ import annotations``).
+        field_type = hints.get(key, f.type)
+        kwargs[key] = _instantiate_for_field(field_type, raw)
     return kwargs
 
 
@@ -240,6 +261,16 @@ def _instantiate_for_field(field_type: Any, raw: Any) -> Any:
         if isinstance(t, type) and issubclass(t, Enum) and isinstance(raw, str):
             try:
                 return t(raw)
+            except ValueError:
+                pass
+        if isinstance(t, type) and t is datetime.date and isinstance(raw, str):
+            try:
+                return datetime.date.fromisoformat(raw)
+            except ValueError:
+                pass
+        if isinstance(t, type) and t is datetime.datetime and isinstance(raw, str):
+            try:
+                return datetime.datetime.fromisoformat(raw)
             except ValueError:
                 pass
     # Dicts / lists → instantiate recursively.
@@ -283,7 +314,7 @@ def _descriptor_from_dict(d: dict) -> TimeSeriesDescriptor:
 # ----- pass 2: resolve references -----
 
 
-def _resolve_references(node: Entity, *, root: Entity) -> None:
+def _resolve_references(node: Element, *, root: Element) -> None:
     for f in dataclasses.fields(node):
         v = getattr(node, f.name)
         if isinstance(v, Reference):
@@ -293,25 +324,26 @@ def _resolve_references(node: Entity, *, root: Entity) -> None:
 
 
 # ---------------------------------------------------------------------
-# Convenience: register every currently-known Entity subclass.
+# Convenience: register every currently-known Element subclass.
 # Called from ``__init__`` after all modules have loaded.
 # ---------------------------------------------------------------------
 
 
-def register_builtin_entities() -> None:
-    """Register all Entity subclasses reachable via __subclasses__ at call time.
+def register_builtin_elements() -> None:
+    """Register all Element subclasses reachable via __subclasses__ at call time.
 
     Use as a fallback so callers don't have to decorate every class manually —
-    the explicit ``@register_entity`` decorator remains the canonical path.
-    Walks both the Node and Edge subtrees under Entity.
+    the explicit ``@register_element`` decorator remains the canonical path.
+    Walks the whole Element subtree (Node, Edge, Asset, Collection, and all
+    their descendants).
     """
 
-    def _walk(cls: Type[Entity]):
+    def _walk(cls: Type[Element]):
         for sub in cls.__subclasses__():
             try:
-                register_entity(sub)
+                register_element(sub)
             except ValueError:
                 pass  # already registered with same class object
             _walk(sub)
 
-    _walk(Entity)
+    _walk(Element)

--- a/energydatamodel/node.py
+++ b/energydatamodel/node.py
@@ -1,39 +1,39 @@
 """Node — the "vertex" subtree of EDM.
 
-A Node is anything that exists as a thing in the model: a physical asset,
-a grid topology node, a sensor, an administrative area, or a container that
-groups other nodes. Adds two fields to :class:`Entity`:
+A Node is anything that exists as a graph vertex in the model: a piece of
+equipment, an administrative area, a grid topology point, or a sensor. Adds
+two fields to :class:`Element`:
 
-* ``members`` — child entities (used by Site, Portfolio, WindFarm, etc.)
+* ``members`` — child elements (used by WindFarm, Network, etc.)
 * ``tz`` — local timezone, where meaningful
 
-Edges between nodes live in the sibling :class:`Edge` subtree, not
-under ``Node``. This split keeps ``members`` and ``tz`` off the Edge
-type where they don't apply.
+Equipment-shaped vertices (WindTurbine, Battery, Sensor, GridNode, ...) mix
+:class:`Asset` via :class:`NodeAsset` in :mod:`energydatamodel.bases`.
+Edges between nodes live in the sibling :class:`Edge` subtree. Logical
+groupings (Portfolio, Site, ...) live in :class:`Collection`, which is a
+sibling of Node under :class:`Element` — not a subclass of Node.
 """
 
 from __future__ import annotations
 
+import datetime
 from dataclasses import dataclass, field
 from typing import ClassVar, List, Optional
 
-import pytz
-
-from energydatamodel.entity import Entity
+from energydatamodel.element import Element
 
 
 @dataclass(repr=False, kw_only=True)
-class Node(Entity):
-    """An Entity that exists as a thing — can hold members and a timezone.
+class Node(Element):
+    """An Element that exists as a graph vertex — can hold members and a timezone.
 
-    Subclassed by Asset, GridNode, Sensor, Area, and the Collection marker
-    class (Portfolio, Site, Region, ...).
+    Subclassed by NodeAsset (equipment) and Area (administrative regions).
     """
 
-    members: List[Entity] = field(default_factory=list)
-    tz: Optional[pytz.BaseTzInfo] = None
+    members: List[Element] = field(default_factory=list)
+    tz: Optional[datetime.tzinfo] = None
 
-    _BASE_FIELDS: ClassVar[frozenset] = Entity._BASE_FIELDS | frozenset({
+    _BASE_FIELDS: ClassVar[frozenset] = Element._BASE_FIELDS | frozenset({
         "members", "tz",
     })
     _CHILDREN_FIELDS: ClassVar[frozenset] = frozenset({"members"})
@@ -41,10 +41,10 @@ class Node(Entity):
     def children(self) -> list:
         return list(self.members)
 
-    def add_child(self, obj: Entity) -> None:
-        if not isinstance(obj, Entity):
+    def add_child(self, obj: Element) -> None:
+        if not isinstance(obj, Element):
             raise TypeError(
-                f"{type(self).__name__} only accepts Entity children, "
+                f"{type(self).__name__} only accepts Element children, "
                 f"got {type(obj).__name__}"
             )
         self.members.append(obj)

--- a/energydatamodel/powergrid.py
+++ b/energydatamodel/powergrid.py
@@ -1,21 +1,22 @@
 """Power-grid concrete classes.
 
+* :class:`EdgeAsset` is the single ``(Edge, Asset)`` mixin point on the edge
+  side. Concrete edge-equipment classes (``Line``, ``Link``, ``Transformer``,
+  ``Pipe``, ``Interconnection``) single-inherit from here.
 * GridNode subclasses (``JunctionPoint``, ``Meter``, ``DeliveryPoint``) live
-  here as concrete topological points. The ``GridNode`` base itself lives in
+  here as concrete topological points. The ``GridNode`` base lives in
   :mod:`energydatamodel.bases`.
-* Edge subclasses (``Line``, ``Link``, ``Transformer``,
-  ``Interconnection``, ``Pipe``) live here. The ``Edge`` base lives in
-  :mod:`energydatamodel.edge`.
 * ``SubNetwork`` and ``Network`` are :class:`Collection` subclasses used to
   group buses + lines.
-* ``Carrier`` is a plain value type (not an Entity).
+* ``Carrier`` is a plain value type (not an Element).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import ClassVar, Optional
 
+from energydatamodel.asset import Asset
 from energydatamodel.bases import GridNode
 from energydatamodel.containers import Collection
 from energydatamodel.edge import Edge
@@ -27,6 +28,21 @@ class Carrier:
 
     name: str
     type: str
+
+
+# ----------------------------------------------------------------- EdgeAsset
+
+
+@dataclass(repr=False, kw_only=True)
+class EdgeAsset(Edge, Asset):
+    """Mixin intermediate: an ``Edge`` that is also an ``Asset``.
+
+    Single mixin point on the edge side. Concrete edge equipment classes
+    (``Line``, ``Link``, ``Transformer``, ``Pipe``, ``Interconnection``)
+    single-inherit from here.
+    """
+
+    _BASE_FIELDS: ClassVar[frozenset] = Edge._BASE_FIELDS | Asset._BASE_FIELDS
 
 
 # --------------------------------------------------------------------- Nodes
@@ -51,28 +67,28 @@ class DeliveryPoint(GridNode):
 
 
 @dataclass(repr=False, kw_only=True)
-class Line(Edge):
+class Line(EdgeAsset):
     """Transmission or distribution line."""
 
     capacity: Optional[float] = None
 
 
 @dataclass(repr=False, kw_only=True)
-class Link(Edge):
+class Link(EdgeAsset):
     """DC link or similar two-node power link."""
 
     capacity: Optional[float] = None
 
 
 @dataclass(repr=False, kw_only=True)
-class Transformer(Edge):
+class Transformer(EdgeAsset):
     """Transformer between two buses."""
 
     capacity: Optional[float] = None
 
 
 @dataclass(repr=False, kw_only=True)
-class Interconnection(Edge):
+class Interconnection(EdgeAsset):
     """Cross-border / cross-area interconnection between two ``Area`` nodes.
 
     The only Edge that carries paired forward/backward capacities —
@@ -84,7 +100,7 @@ class Interconnection(Edge):
 
 
 @dataclass(repr=False, kw_only=True)
-class Pipe(Edge):
+class Pipe(EdgeAsset):
     """Gas / heat pipe."""
 
     capacity: Optional[float] = None

--- a/energydatamodel/reference.py
+++ b/energydatamodel/reference.py
@@ -1,8 +1,8 @@
 """Path-based cross-tree references.
 
-A ``Reference[T]`` points to another Entity by its position in the tree
+A ``Reference[T]`` points to another Element by its position in the tree
 (e.g. ``"Nordic/SE4"``) rather than by Python identity. The reference starts
-as a path string and is resolved to an Entity object once the tree is loaded.
+as a path string and is resolved to an Element object once the tree is loaded.
 """
 
 from __future__ import annotations
@@ -10,10 +10,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Generic, TypeVar, Union
 
 if TYPE_CHECKING:
-    from energydatamodel.entity import Entity
+    from energydatamodel.element import Element
 
 
-T = TypeVar("T", bound="Entity")
+T = TypeVar("T", bound="Element")
 
 
 class UnresolvedReferenceError(LookupError):
@@ -21,15 +21,15 @@ class UnresolvedReferenceError(LookupError):
 
 
 class Reference(Generic[T]):
-    """Typed marker for a cross-tree reference to another Entity.
+    """Typed marker for a cross-tree reference to another Element.
 
-    Stores either a ``str`` path (pre-resolve) or an Entity object (post-resolve).
+    Stores either a ``str`` path (pre-resolve) or an Element object (post-resolve).
     Used on fields like ``Edge.from_entity`` / ``Edge.to_entity``.
     """
 
     __slots__ = ("_target",)
 
-    def __init__(self, target: Union[str, "Entity"]):
+    def __init__(self, target: Union[str, "Element"]):
         self._target = target
 
     # -----------------------------------------------------------------
@@ -37,11 +37,11 @@ class Reference(Generic[T]):
         return not isinstance(self._target, str)
 
     @property
-    def target(self) -> Union[str, "Entity"]:
+    def target(self) -> Union[str, "Element"]:
         return self._target
 
-    def get(self) -> "Entity":
-        """Return the resolved Entity. Raises if still a path string."""
+    def get(self) -> "Element":
+        """Return the resolved Element. Raises if still a path string."""
         if isinstance(self._target, str):
             raise UnresolvedReferenceError(
                 f"Reference to {self._target!r} has not been resolved."
@@ -49,7 +49,7 @@ class Reference(Generic[T]):
         return self._target
 
     # -----------------------------------------------------------------
-    def resolve(self, root: "Entity") -> "Entity":
+    def resolve(self, root: "Element") -> "Element":
         """Resolve the reference against ``root``. Idempotent."""
         if not isinstance(self._target, str):
             return self._target
@@ -62,11 +62,11 @@ class Reference(Generic[T]):
         self._target = obj
         return obj
 
-    def path(self, root: "Entity") -> str:
+    def path(self, root: "Element") -> str:
         """Canonical path from ``root`` to the target.
 
         Returns the same canonical full path whether ``self`` holds a string
-        path or a resolved Entity. Does not mutate ``self``. Raises
+        path or a resolved Element. Does not mutate ``self``. Raises
         ``UnresolvedReferenceError`` if the target is not reachable from ``root``.
         """
         if isinstance(self._target, str):
@@ -122,7 +122,7 @@ class Reference(Generic[T]):
 # ---------------------------------------------------------------------
 
 
-def _lookup_by_path(root: "Entity", path: str) -> "Entity | None":
+def _lookup_by_path(root: "Element", path: str) -> "Element | None":
     """Resolve a slash-separated path like ``"Nordic/SE4"`` by walking ``name``s."""
     parts = [p for p in path.split("/") if p]
     if not parts:
@@ -143,7 +143,7 @@ def _lookup_by_path(root: "Entity", path: str) -> "Entity | None":
     return node
 
 
-def _path_to(root: "Entity", target: "Entity") -> "str | None":
+def _path_to(root: "Element", target: "Element") -> "str | None":
     """Compute path from root → target, return None if target is not in the tree."""
     trail: list[str] = []
 

--- a/energydatamodel/solar.py
+++ b/energydatamodel/solar.py
@@ -9,8 +9,8 @@ from typing import Optional, Union
 import pandas as pd
 import pvlib
 
-from energydatamodel.bases import Asset
-from energydatamodel.entity import Entity
+from energydatamodel.bases import NodeAsset
+from energydatamodel.element import Element
 
 
 @dataclass
@@ -32,7 +32,7 @@ class SingleAxisTrackerMount:
 
 
 @dataclass(repr=False, kw_only=True)
-class PVArray(Asset):
+class PVArray(NodeAsset):
     capacity: Optional[float] = None
     surface_azimuth: Optional[float] = None
     surface_tilt: Optional[float] = None
@@ -45,7 +45,7 @@ class PVArray(Asset):
 
 
 @dataclass(repr=False, kw_only=True)
-class PVSystem(Asset):
+class PVSystem(NodeAsset):
     """A PV system — an Asset that contains :class:`PVArray` members.
 
     Stored in the inherited ``members`` list. ``add_child`` enforces the type
@@ -76,7 +76,7 @@ class PVSystem(Asset):
                 )
             )
 
-    def add_child(self, obj: Entity) -> None:
+    def add_child(self, obj: Element) -> None:
         if not isinstance(obj, PVArray):
             raise TypeError(
                 f"PVSystem only accepts PVArray children, got {type(obj).__name__}"
@@ -109,7 +109,7 @@ class PVSystem(Asset):
 
 
 @dataclass(repr=False, kw_only=True)
-class SolarPowerArea(Asset):
+class SolarPowerArea(NodeAsset):
     """A solar-power-potential area.
 
     The area's polygon lives in the inherited ``geometry`` field.

--- a/energydatamodel/weathersensor.py
+++ b/energydatamodel/weathersensor.py
@@ -1,32 +1,32 @@
 """Weather sensors — concrete :class:`Sensor` subclasses observing
-environmental variables."""
+environmental variables. ``height`` is inherited from :class:`Sensor`.
+"""
 
 from dataclasses import dataclass
-from typing import Optional
 
 from energydatamodel.bases import Sensor
 
 
 @dataclass(repr=False, kw_only=True)
 class TemperatureSensor(Sensor):
-    height: Optional[float] = None
+    pass
 
 
 @dataclass(repr=False, kw_only=True)
 class WindSpeedSensor(Sensor):
-    height: Optional[float] = None
+    pass
 
 
 @dataclass(repr=False, kw_only=True)
 class RadiationSensor(Sensor):
-    height: Optional[float] = None
+    pass
 
 
 @dataclass(repr=False, kw_only=True)
 class RainSensor(Sensor):
-    height: Optional[float] = None
+    pass
 
 
 @dataclass(repr=False, kw_only=True)
 class HumiditySensor(Sensor):
-    height: Optional[float] = None
+    pass

--- a/energydatamodel/wind.py
+++ b/energydatamodel/wind.py
@@ -7,12 +7,12 @@ from typing import Optional, Union
 
 import pandas as pd
 
-from energydatamodel.bases import Asset
-from energydatamodel.entity import Entity
+from energydatamodel.bases import NodeAsset
+from energydatamodel.element import Element
 
 
 @dataclass(repr=False, kw_only=True)
-class WindTurbine(Asset):
+class WindTurbine(NodeAsset):
     capacity: Optional[Union[float, pd.DataFrame]] = None
     hub_height: Optional[float] = None
     rotor_diameter: Optional[float] = None
@@ -22,7 +22,7 @@ class WindTurbine(Asset):
 
 
 @dataclass(repr=False, kw_only=True)
-class WindFarm(Asset):
+class WindFarm(NodeAsset):
     """A wind farm — an Asset that contains :class:`WindTurbine` members.
 
     Stored in the inherited ``members`` list (no separate typed field).
@@ -32,7 +32,7 @@ class WindFarm(Asset):
     capacity: Optional[Union[float, pd.DataFrame]] = None
     farm_efficiency: Optional[pd.DataFrame] = None
 
-    def add_child(self, obj: Entity) -> None:
+    def add_child(self, obj: Element) -> None:
         if not isinstance(obj, WindTurbine):
             raise TypeError(
                 f"WindFarm only accepts WindTurbine children, got {type(obj).__name__}"
@@ -41,7 +41,7 @@ class WindFarm(Asset):
 
 
 @dataclass(repr=False, kw_only=True)
-class WindPowerArea(Asset):
+class WindPowerArea(NodeAsset):
     """A wind-power-potential area (e.g. offshore zone).
 
     The area's polygon lives in the inherited ``geometry`` field. Constituent

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -3,59 +3,129 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# EnergyDataModel — Quickstart\n\n`energydatamodel` (EDM) is a typed, tree-shaped data model for describing energy systems — assets, areas, interconnections, and the time series attached to each. Every structural class ultimately inherits from a single `Entity` root, with two intermediate bases:\n\n- **`Node`** — anything that exists as a thing in the model. Has `members` (child entities) and `tz`. Subclassed by `Asset`, `GridNode`, `Sensor`, `Area`, and `Collection`.\n- **`Edge`** — a directed relationship between two nodes (`Line`, `Transformer`, `Interconnection`, `Pipe`).\n\nThis notebook walks through:\n\n1. Building a small portfolio tree.\n2. Attaching time-series descriptors via the energy vocabulary.\n3. Tree walking (`children()`, `to_tree()`).\n4. Cross-tree references with `Reference[T]`.\n5. Full JSON round-trip.\n6. Tour of the powergrid + area types."
+   "source": [
+    "# EnergyDataModel — Quickstart\n",
+    "\n",
+    "`energydatamodel` (EDM) is a typed, tree-shaped data model for describing energy systems — assets, areas, interconnections, and the time series attached to each. Every structural class ultimately inherits from a single `Element` root, with three sibling subtrees and one cross-cutting mixin:\n",
+    "\n",
+    "- **`Node`** — graph vertices (equipment, areas, sensors, grid topology points). Has `members` and `tz`. Subclassed by `NodeAsset`, `GridNode`, `Sensor`, and `Area`.\n",
+    "- **`Edge`** — a directed relationship between two nodes (`Line`, `Transformer`, `Interconnection`, `Pipe`), via `EdgeAsset`.\n",
+    "- **`Collection`** — logical groupings (`Portfolio`, `Site`, `Region`, ...). Has `members` and `tz`. Not a graph vertex.\n",
+    "- **`Asset`** — cross-cutting mixin marking physical equipment (`commissioning_date`). Mixed into `NodeAsset` / `EdgeAsset`.\n",
+    "\n",
+    "This notebook walks through:\n",
+    "\n",
+    "1. Building a small portfolio tree.\n",
+    "2. Attaching time-series descriptors via the energy vocabulary.\n",
+    "3. Tree walking (`children()`, `to_tree()`).\n",
+    "4. Cross-tree references with `Reference[T]`.\n",
+    "5. Full JSON round-trip.\n",
+    "6. Tour of the powergrid + area types."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:11.695662Z",
-     "iopub.status.busy": "2026-04-13T17:43:11.695303Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.732617Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.731722Z"
+     "iopub.execute_input": "2026-04-21T10:46:13.329371Z",
+     "iopub.status.busy": "2026-04-21T10:46:13.328996Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.245570Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.244751Z"
     }
    },
    "outputs": [],
-   "source": "import json\n\nimport energydatamodel as edm\nfrom shapely.geometry import Point, Polygon\nfrom timedatamodel import DataType, Frequency"
+   "source": [
+    "import json\n",
+    "\n",
+    "import energydatamodel as edm\n",
+    "from shapely.geometry import Point, Polygon\n",
+    "from timedatamodel import DataType, Frequency"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 1. Build a tree\n\nStart from the leaves (turbines) and aggregate upward. Every `Node` takes a `members` list of child entities. Use `geometry=Point(lon, lat)` for locations."
+   "source": [
+    "## 1. Build a tree\n",
+    "\n",
+    "Start from the leaves (turbines) and aggregate upward. Every `Node` takes a `members` list of child entities. Use `geometry=Point(lon, lat)` for locations."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.735565Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.735180Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.740152Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.739307Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.248118Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.247757Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.252439Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.251762Z"
     }
    },
    "outputs": [],
-   "source": "t01 = edm.WindTurbine(name=\"T01\", capacity=3.5, hub_height=80, geometry=Point(12.78, 55.51))\nt02 = edm.WindTurbine(name=\"T02\", capacity=3.5, hub_height=80, geometry=Point(12.79, 55.52))\n\nlillgrund = edm.WindFarm(name=\"Lillgrund\", capacity=110, members=[t01, t02])\n\npv_array = edm.PVArray(capacity=5.0, surface_tilt=25, surface_azimuth=180)\nrooftop = edm.PVSystem(name=\"Rooftop-01\", capacity=5.0, surface_tilt=25, surface_azimuth=180, members=[pv_array])\n\nsite = edm.Site(name=\"Sweden-Offshore\", geometry=Point(12.8, 55.5), members=[lillgrund, rooftop])"
+   "source": [
+    "t01 = edm.WindTurbine(name=\"T01\", capacity=3.5, hub_height=80, geometry=Point(12.78, 55.51))\n",
+    "t02 = edm.WindTurbine(name=\"T02\", capacity=3.5, hub_height=80, geometry=Point(12.79, 55.52))\n",
+    "\n",
+    "lillgrund = edm.WindFarm(name=\"Lillgrund\", capacity=110, members=[t01, t02])\n",
+    "\n",
+    "pv_array = edm.PVArray(capacity=5.0, surface_tilt=25, surface_azimuth=180)\n",
+    "rooftop = edm.PVSystem(name=\"Rooftop-01\", capacity=5.0, surface_tilt=25, surface_azimuth=180, members=[pv_array])\n",
+    "\n",
+    "site = edm.Site(name=\"Sweden-Offshore\", geometry=Point(12.8, 55.5), members=[lillgrund, rooftop])"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Other asset types\n\nBeyond wind/solar, EDM ships `Battery`, `HeatPump`, `Building`, `House`, `Reservoir`/`HydroTurbine`/`HydroPowerPlant`, and weather sensors. `Building` and `House` are `Asset`s that also contain child entities via `members`. Locations are set via `geometry=Point(lon, lat)`."
+   "source": [
+    "### Other asset types\n",
+    "\n",
+    "Beyond wind/solar, EDM ships `Battery`, `HeatPump`, `Building`, `House`, `Reservoir`/`HydroTurbine`/`HydroPowerPlant`, and weather sensors. `Building` and `House` are `Asset`s that also contain child entities via `members`. Locations are set via `geometry=Point(lon, lat)`."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.742608Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.742260Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.758280Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.757434Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.255202Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.255019Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.260843Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.260156Z"
     }
    },
-   "outputs": [],
-   "source": "import pytz\n\nhp = edm.HeatPump(name=\"HP1\", capacity=8, cop=3.5, energy_source=\"electricity\",\n                  timeseries=[edm.heating_demand(unit=\"kW\")])\nbat = edm.Battery(name=\"Bat1\", storage_capacity=10, max_charge=5, max_discharge=5)\n\nhouse = edm.House(\n    name=\"House-42\",\n    geometry=Point(11.97, 57.71),\n    tz=pytz.timezone(\"Europe/Stockholm\"),\n    members=[hp, bat],\n)\nprint(house.to_tree())\nprint()\nprint(\"has_battery:\", house.has_battery(), \" batteries:\", [b.name for b in house.get_batteries()])"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "House('House-42')\n",
+      "├── HeatPump('HP1')\n",
+      "└── Battery('Bat1')\n",
+      "\n",
+      "has_battery: True  batteries: ['Bat1']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from zoneinfo import ZoneInfo\n",
+    "\n",
+    "hp = edm.HeatPump(name=\"HP1\", capacity=8, cop=3.5, energy_source=\"electricity\",\n",
+    "                  timeseries=[edm.heating_demand(unit=\"kW\")])\n",
+    "bat = edm.Battery(name=\"Bat1\", storage_capacity=10, max_charge=5, max_discharge=5)\n",
+    "\n",
+    "house = edm.House(\n",
+    "    name=\"House-42\",\n",
+    "    geometry=Point(11.97, 57.71),\n",
+    "    tz=ZoneInfo(\"Europe/Stockholm\"),\n",
+    "    members=[hp, bat],\n",
+    ")\n",
+    "print(house.to_tree())\n",
+    "print()\n",
+    "print(\"has_battery:\", house.has_battery(), \" batteries:\", [b.name for b in house.get_batteries()])"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -73,10 +143,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.828202Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.827881Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.836256Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.835381Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.291380Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.291216Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.300113Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.297875Z"
     }
    },
    "outputs": [
@@ -109,10 +179,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.838389Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.838043Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.842508Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.841763Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.302687Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.302424Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.305771Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.305440Z"
     }
    },
    "outputs": [
@@ -137,21 +207,59 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 3. Areas + Edges + cross-tree references\n\n`Area(Node)` represents bidding zones, control areas, countries, weather cells — each as a proper subclass (`BiddingZone`, `Country`, etc.), distinguished by `isinstance`.\n\n`Interconnection(Edge)` connects two areas. Because the connected nodes live elsewhere in the tree, we reference them by path via `Reference[T]` — the reference holds a path string until the tree is loaded, then resolves to the object."
+   "source": [
+    "## 3. Areas + Edges + cross-tree references\n",
+    "\n",
+    "`Area(Node)` represents bidding zones, control areas, countries, weather cells — each as a proper subclass (`BiddingZone`, `Country`, etc.), distinguished by `isinstance`.\n",
+    "\n",
+    "`Interconnection(Edge)` connects two areas. Because the connected nodes live elsewhere in the tree, we reference them by path via `Reference[T]` — the reference holds a path string until the tree is loaded, then resolves to the object."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.844556Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.844341Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.850498Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.849368Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.308401Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.308248Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.311942Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.311245Z"
     }
    },
-   "outputs": [],
-   "source": "se4 = edm.BiddingZone(name=\"SE4\", timeseries=[edm.spot_price(unit=\"EUR / MWh\")])\ndk2 = edm.BiddingZone(name=\"DK2\", timeseries=[edm.spot_price(unit=\"EUR / MWh\")])\n\nicx = edm.Interconnection(\n    name=\"SE4-DK2\",\n    from_entity=edm.Reference(\"SE4\"),\n    to_entity=edm.Reference(\"DK2\"),\n    capacity_forward=1700,\n    capacity_backward=1300,\n    timeseries=[edm.cross_border_flow(unit=\"MW\")],\n)\n\nportfolio = edm.Portfolio(name=\"Nordic\", members=[site, se4, dk2, icx])\nprint(portfolio.to_tree())"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Portfolio('Nordic')\n",
+      "├── Site('Sweden-Offshore')\n",
+      "│   ├── WindFarm('Lillgrund')\n",
+      "│   │   ├── WindTurbine('T01')\n",
+      "│   │   └── WindTurbine('T02')\n",
+      "│   └── PVSystem('Rooftop-01')\n",
+      "│       └── PVArray()\n",
+      "├── BiddingZone('SE4')\n",
+      "├── BiddingZone('DK2')\n",
+      "└── Interconnection('SE4-DK2')\n"
+     ]
+    }
+   ],
+   "source": [
+    "se4 = edm.BiddingZone(name=\"SE4\", timeseries=[edm.spot_price(unit=\"EUR / MWh\")])\n",
+    "dk2 = edm.BiddingZone(name=\"DK2\", timeseries=[edm.spot_price(unit=\"EUR / MWh\")])\n",
+    "\n",
+    "icx = edm.Interconnection(\n",
+    "    name=\"SE4-DK2\",\n",
+    "    from_entity=edm.Reference(\"SE4\"),\n",
+    "    to_entity=edm.Reference(\"DK2\"),\n",
+    "    capacity_forward=1700,\n",
+    "    capacity_backward=1300,\n",
+    "    timeseries=[edm.cross_border_flow(unit=\"MW\")],\n",
+    ")\n",
+    "\n",
+    "portfolio = edm.Portfolio(name=\"Nordic\", members=[site, se4, dk2, icx])\n",
+    "print(portfolio.to_tree())"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -167,10 +275,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.852944Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.852686Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.863126Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.862209Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.313568Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.313404Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.319716Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.318712Z"
     }
    },
    "outputs": [
@@ -223,10 +331,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.865401Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.865210Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.869563Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.868618Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.321705Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.321425Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.326489Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.325433Z"
     }
    },
    "outputs": [
@@ -241,8 +349,8 @@
       "      WindTurbine('T02')\n",
       "    PVSystem('Rooftop-01')\n",
       "      PVArray(None)\n",
-      "  Area('SE4')\n",
-      "  Area('DK2')\n",
+      "  BiddingZone('SE4')\n",
+      "  BiddingZone('DK2')\n",
       "  Interconnection('SE4-DK2')\n"
      ]
     }
@@ -261,10 +369,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.871630Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.871403Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.875343Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.874351Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.327859Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.327699Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.330443Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.329772Z"
     }
    },
    "outputs": [
@@ -274,7 +382,7 @@
      "text": [
       "Portfolio('Rebuilt')\n",
       "├── Site('Sweden-Offshore')\n",
-      "└── Area('SE4')\n"
+      "└── BiddingZone('SE4')\n"
      ]
     }
    ],
@@ -302,10 +410,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.877845Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.877522Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.884289Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.883093Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.332115Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.331931Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.335107Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.334643Z"
     }
    },
    "outputs": [
@@ -320,11 +428,19 @@
       "    {\n",
       "      \"type\": \"Site\",\n",
       "      \"name\": \"Sweden-Offshore\",\n",
+      "      \"geometry\": {\n",
+      "        \"__geometry__\": true,\n",
+      "        \"type\": \"Point\",\n",
+      "        \"coordinates\": [\n",
+      "          12.8,\n",
+      "          55.5\n",
+      "        ]\n",
+      "      },\n",
       "      \"members\": [\n",
       "        {\n",
       "          \"type\": \"WindFarm\",\n",
       "          \"name\": \"Lillgrund\",\n",
-      "          \"wind_turbines\": [\n",
+      "          \"members\": [\n",
       "            {\n",
       "              \"type\": \"WindTurbine\",\n",
       "              \"name\": \"T01\",\n",
@@ -340,32 +456,28 @@
       "                  \"description\": null\n",
       "                }\n",
       "              ],\n",
-      "              \"location\": {\n",
-      "                \"__type__\": \"GeoLocation\",\n",
-      "                \"longitude\": 12.78,\n",
-      "                \"latitude\": 55.51,\n",
-      "                \"tz\": \"UTC\",\n",
-      "                \"altitude\": null,\n",
-      "                \"name\": null\n",
+      "              \"geometry\": {\n",
+      "                \"__geometry__\": true,\n",
+      "                \"type\": \"Point\",\n",
+      "                \"coordinates\": [\n",
+      "                  12.78,\n",
+      "                  55.51\n",
+      "                ]\n",
       "              },\n",
-      "              \"latitude\": 55.51,\n",
-      "              \"longitude\": 12.78,\n",
       "              \"capacity\": 3.5,\n",
       "              \"hub_height\": 80\n",
       "            },\n",
       "            {\n",
       "              \"type\": \"WindTurbine\",\n",
       "              \"name\": \"T02\",\n",
-      "              \"location\": {\n",
-      "                \"__type__\": \"GeoLocation\",\n",
-      "                \"longitude\": 12.79,\n",
-      "                \"latitude\": 55.52,\n",
-      "                \"tz\": \"UTC\",\n",
-      "                \"altitude\": null,\n",
-      "                \"name\": null\n",
+      "              \"geometry\": {\n",
+      "                \"__geometry__\": true,\n",
+      "                \"type\": \"Point\",\n",
+      "                \"coordinates\": [\n",
+      "                  12.79,\n",
+      "                  55.52\n",
+      "                ]\n",
       "              },\n",
-      "              \"latitude\": 55.52,\n",
-      "              \"longitude\": 12.79,\n",
       "              \"capacity\": 3.5,\n",
       "              \"hub_height\": 80\n",
       "            }\n",
@@ -387,7 +499,7 @@
       "              \"description\": null\n",
       "            }\n",
       "          ],\n",
-      "          \"pv_arrays\": [\n",
+      "          \"members\": [\n",
       "            {\n",
       "              \"type\": \"PVArray\",\n",
       "              \"capacity\": 5.0,\n",
@@ -402,20 +514,10 @@
       "          \"module_type\": \"glass_polymer\",\n",
       "          \"racking_model\": \"open_rack\"\n",
       "        }\n",
-      "      ],\n",
-      "      \"longitude\": 12.8,\n",
-      "      \"latitude\": 55.5,\n",
-      "      \"location\": {\n",
-      "        \"__type__\": \"GeoLocation\",\n",
-      "        \"longitude\": 12.8,\n",
-      "        \"latitude\": 55.5,\n",
-      "        \"tz\": \"UTC\",\n",
-      "        \"altitude\": null,\n",
-      "        \"name\": null\n",
-      "      }\n",
+      "      ]\n",
       "    },\n",
       "    {\n",
-      "      \"type\": \"Area\",\n",
+      "      \"type\": \"BiddingZone\",\n",
       "      \"name\": \"SE4\",\n",
       "      \"timeseries\": [\n",
       "        {\n",
@@ -429,7 +531,6 @@
       "          \"description\": null\n",
       "        }\n",
       "      ],\n",
-      "      \"scope\": \"bidding_zone\",\n",
       "      \"geometry\": {\n",
       "        \"__geometry__\": true,\n",
       "        \"type\": \"Polygon\",\n",
@@ -460,7 +561,7 @@
       "      }\n",
       "    },\n",
       "    {\n",
-      "      \"type\": \"Area\",\n",
+      "      \"type\": \"BiddingZone\",\n",
       "      \"name\": \"DK2\",\n",
       "      \"timeseries\": [\n",
       "        {\n",
@@ -474,7 +575,6 @@
       "          \"description\": null\n",
       "        }\n",
       "      ],\n",
-      "      \"scope\": \"bidding_zone\",\n",
       "      \"geometry\": {\n",
       "        \"__geometry__\": true,\n",
       "        \"type\": \"Polygon\",\n",
@@ -519,10 +619,10 @@
       "          \"description\": null\n",
       "        }\n",
       "      ],\n",
-      "      \"from_node\": {\n",
+      "      \"from_entity\": {\n",
       "        \"__ref__\": \"Nordic/SE4\"\n",
       "      },\n",
-      "      \"to_node\": {\n",
+      "      \"to_entity\": {\n",
       "        \"__ref__\": \"Nordic/DK2\"\n",
       "      },\n",
       "      \"directed\": true,\n",
@@ -541,17 +641,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.887322Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.886703Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.895586Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.894450Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.336512Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.336346Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.343083Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.342185Z"
     }
    },
-   "outputs": [],
-   "source": "# Round-trip.\nrestored = edm.Portfolio.from_json(js)\n\n# Byte-equal after re-dump.\nassert json.dumps(js, default=str) == json.dumps(restored.to_json(), default=str)\n\n# References are resolved — from_entity/to_entity now point at the actual BiddingZone objects.\nicx_restored = next(m for m in restored.members if isinstance(m, edm.Interconnection))\nprint(\"from_entity resolved:\", icx_restored.from_entity.is_resolved(), \"→\", icx_restored.from_entity.get().name)\nprint(\"to_entity   resolved:\", icx_restored.to_entity.is_resolved(), \"→\", icx_restored.to_entity.get().name)"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "from_entity resolved: True → SE4\n",
+      "to_entity   resolved: True → DK2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Round-trip.\n",
+    "restored = edm.Portfolio.from_json(js)\n",
+    "\n",
+    "# Byte-equal after re-dump.\n",
+    "assert json.dumps(js, default=str) == json.dumps(restored.to_json(), default=str)\n",
+    "\n",
+    "# References are resolved — from_entity/to_entity now point at the actual BiddingZone objects.\n",
+    "icx_restored = next(m for m in restored.members if isinstance(m, edm.Interconnection))\n",
+    "print(\"from_entity resolved:\", icx_restored.from_entity.is_resolved(), \"→\", icx_restored.from_entity.get().name)\n",
+    "print(\"to_entity   resolved:\", icx_restored.to_entity.is_resolved(), \"→\", icx_restored.to_entity.get().name)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -564,36 +684,101 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.898116Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.897928Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.902396Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.901439Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.344575Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.344430Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.347987Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.347315Z"
     }
    },
-   "outputs": [],
-   "source": "from energydatamodel.reference import UnresolvedReferenceError\n\nbroken = edm.Portfolio(\n    name=\"Broken\",\n    members=[edm.Interconnection(name=\"X\", from_entity=edm.Reference(\"Ghost\"), to_entity=edm.Reference(\"Ghost2\"))],\n)\ntry:\n    edm.Portfolio.from_json(broken.to_json())\nexcept UnresolvedReferenceError as e:\n    print(\"caught:\", e)"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "caught: Reference 'Ghost' does not resolve against Portfolio('Broken')\n"
+     ]
+    }
+   ],
+   "source": [
+    "from energydatamodel.reference import UnresolvedReferenceError\n",
+    "\n",
+    "broken = edm.Portfolio(\n",
+    "    name=\"Broken\",\n",
+    "    members=[edm.Interconnection(name=\"X\", from_entity=edm.Reference(\"Ghost\"), to_entity=edm.Reference(\"Ghost2\"))],\n",
+    ")\n",
+    "try:\n",
+    "    edm.Portfolio.from_json(broken.to_json())\n",
+    "except UnresolvedReferenceError as e:\n",
+    "    print(\"caught:\", e)"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 6. Powergrid tour\n\nThe powergrid types split by structural kind:\n\n| Kind         | Classes                                                            |\n|--------------|--------------------------------------------------------------------|\n| `Node`       | `JunctionPoint`, `Meter`, `DeliveryPoint`, `Area`                  |\n| `Edge`       | `Line`, `Link`, `Transformer`, `Interconnection`, `Pipe`           |\n| `Collection` | `SubNetwork`, `Network`, `Site`, `Portfolio`, `Region`, `MultiSite`|"
+   "source": [
+    "## 6. Powergrid tour\n",
+    "\n",
+    "The powergrid types split by structural kind:\n",
+    "\n",
+    "| Kind         | Classes                                                            |\n",
+    "|--------------|--------------------------------------------------------------------|\n",
+    "| `Node`       | `JunctionPoint`, `Meter`, `DeliveryPoint`, `Area`                  |\n",
+    "| `Edge`       | `Line`, `Link`, `Transformer`, `Interconnection`, `Pipe`           |\n",
+    "| `Collection` | `SubNetwork`, `Network`, `Site`, `Portfolio`, `Region`, `MultiSite`|"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.904807Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.904586Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.911050Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.910228Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.349515Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.349362Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.353392Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.352685Z"
     }
    },
-   "outputs": [],
-   "source": "electricity = edm.Carrier(name=\"electricity\", type=\"renewable\")\n\nbus_a = edm.JunctionPoint(name=\"BusA\", carrier=electricity)\nbus_b = edm.JunctionPoint(name=\"BusB\", carrier=electricity)\n\nline = edm.Line(\n    name=\"A-B\",\n    from_entity=edm.Reference(\"BusA\"),\n    to_entity=edm.Reference(\"BusB\"),\n    capacity=400.0,\n)\n\n# Pipes use the same Edge contract — direction + capacity + medium.\ngas = edm.Pipe(\n    name=\"A-B-gas\",\n    from_entity=edm.Reference(\"BusA\"),\n    to_entity=edm.Reference(\"BusB\"),\n    capacity=50.0,\n    medium=\"gas\",\n)\n\nnet = edm.Network(name=\"Mini-Grid\", members=[bus_a, bus_b, line, gas])\nprint(net.to_tree())"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Network('Mini-Grid')\n",
+      "├── JunctionPoint('BusA')\n",
+      "├── JunctionPoint('BusB')\n",
+      "├── Line('A-B')\n",
+      "└── Pipe('A-B-gas')\n"
+     ]
+    }
+   ],
+   "source": [
+    "electricity = edm.Carrier(name=\"electricity\", type=\"renewable\")\n",
+    "\n",
+    "bus_a = edm.JunctionPoint(name=\"BusA\", carrier=electricity)\n",
+    "bus_b = edm.JunctionPoint(name=\"BusB\", carrier=electricity)\n",
+    "\n",
+    "line = edm.Line(\n",
+    "    name=\"A-B\",\n",
+    "    from_entity=edm.Reference(\"BusA\"),\n",
+    "    to_entity=edm.Reference(\"BusB\"),\n",
+    "    capacity=400.0,\n",
+    ")\n",
+    "\n",
+    "# Pipes use the same Edge contract — direction + capacity + medium.\n",
+    "gas = edm.Pipe(\n",
+    "    name=\"A-B-gas\",\n",
+    "    from_entity=edm.Reference(\"BusA\"),\n",
+    "    to_entity=edm.Reference(\"BusB\"),\n",
+    "    capacity=50.0,\n",
+    "    medium=\"gas\",\n",
+    ")\n",
+    "\n",
+    "net = edm.Network(name=\"Mini-Grid\", members=[bus_a, bus_b, line, gas])\n",
+    "print(net.to_tree())"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -609,10 +794,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-13T17:43:12.913502Z",
-     "iopub.status.busy": "2026-04-13T17:43:12.913289Z",
-     "iopub.status.idle": "2026-04-13T17:43:12.917284Z",
-     "shell.execute_reply": "2026-04-13T17:43:12.916610Z"
+     "iopub.execute_input": "2026-04-21T10:46:14.355167Z",
+     "iopub.status.busy": "2026-04-21T10:46:14.354977Z",
+     "iopub.status.idle": "2026-04-21T10:46:14.357799Z",
+     "shell.execute_reply": "2026-04-21T10:46:14.357358Z"
     }
    },
    "outputs": [
@@ -634,7 +819,11 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "---\n\nThat's the whole surface: `Entity` → `Node`/`Edge`, with `Collection` as a marker under `Node`, plus `Reference[T]` for cross-tree links and an energy vocabulary for time series. See `tests/` for exhaustive usage; see `energydatamodel/json_io.py` if you need to register custom `Entity` subclasses for JSON dispatch."
+   "source": [
+    "---\n",
+    "\n",
+    "That's the whole surface: `Element` as the root, `Node`/`Edge`/`Collection` as the three sibling subtrees, `Asset` as a cross-cutting mixin, plus `Reference[T]` for cross-tree links and an energy vocabulary for time series. See `tests/` for exhaustive usage; see `energydatamodel/json_io.py` if you need to register custom `Element` subclasses for JSON dispatch."
+   ]
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ dependencies = [
     "geopandas>=1.0.1",
     "pandas>=2.2.2",
     "pvlib>=0.12.0",
-    "pytz>=2025.1",
     "shapely>=2.0.7",
     "timedatamodel>=0.2.1",
+    "tzdata; sys_platform == 'win32'",
 ]
 
 [project.urls]

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,42 +1,41 @@
-"""Tests for Entity, Node, Edge, and the semantic intermediate bases."""
+"""Tests for Element, Node, Edge, Asset mixin, and the role intermediates."""
 
 import pytest
 from shapely.geometry import Point, Polygon
-from timedatamodel import TimeSeriesDescriptor
 
 import energydatamodel as edm
 
 
-class TestEntity:
+class TestElement:
     def test_instantiate_direct(self):
-        e = edm.Entity(name="root")
+        e = edm.Element(name="root")
         assert e.name == "root"
         assert e._id is None
         assert e.timeseries == []
         assert e.geometry is None
 
     def test_default_children_empty(self):
-        e = edm.Entity(name="x")
+        e = edm.Element(name="x")
         assert e.children() == []
 
     def test_default_add_child_raises(self):
-        e = edm.Entity(name="x")
+        e = edm.Element(name="x")
         with pytest.raises(TypeError, match="does not support"):
             e.add_child(edm.Node(name="y"))
 
     def test_id_ignored_by_tree_logic(self):
-        e = edm.Entity(name="x", _id="abc-123")
+        e = edm.Element(name="x", _id="abc-123")
         assert e._id == "abc-123"
         assert e.to_properties() == {}
 
     def test_geometry_point_lat_lon(self):
-        e = edm.Entity(name="x", geometry=Point(13.0, 55.0))
+        e = edm.Element(name="x", geometry=Point(13.0, 55.0))
         assert e.lon == 13.0
         assert e.lat == 55.0
 
     def test_geometry_polygon_no_lat_lon(self):
         poly = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
-        e = edm.Entity(name="x", geometry=poly)
+        e = edm.Element(name="x", geometry=poly)
         assert e.lat is None
         assert e.lon is None
         assert e.centroid is not None
@@ -50,16 +49,15 @@ class TestNode:
         assert c.members == [child]
         assert c.children() == [child]
 
-    def test_add_child_rejects_non_entity(self):
+    def test_add_child_rejects_non_element(self):
         c = edm.Node(name="c")
         with pytest.raises(TypeError):
-            c.add_child("not an entity")
+            c.add_child("not an element")
 
 
 class TestEdge:
     def test_no_members_field(self):
-        # Edge sits sibling to Node under Entity; it does not carry
-        # members or tz.
+        # Edge sits sibling to Node under Element; does not carry members or tz.
         ic = edm.Interconnection(name="x")
         assert not hasattr(ic, "members")
         assert not hasattr(ic, "tz")
@@ -77,11 +75,66 @@ class TestEdge:
         assert ic.directed is True
 
 
-class TestAsset:
-    def test_geometry_point(self):
-        t = edm.WindTurbine(name="T01", capacity=3.5, geometry=Point(13.0, 55.0))
-        assert t.lat == 55.0
-        assert t.lon == 13.0
+class TestAssetMixin:
+    """Asset is a mixin — marker for physical equipment on both graph sides."""
+
+    def test_node_asset_classes_are_asset(self):
+        assert isinstance(edm.WindTurbine(name="t"), edm.Asset)
+        assert isinstance(edm.Battery(name="b"), edm.Asset)
+        assert isinstance(edm.HeatPump(name="h"), edm.Asset)
+        assert isinstance(edm.Building(name="b"), edm.Asset)
+
+    def test_sensor_and_gridnode_are_asset(self):
+        assert isinstance(edm.TemperatureSensor(name="t"), edm.Asset)
+        assert isinstance(edm.Meter(name="m"), edm.Asset)
+        assert isinstance(edm.DeliveryPoint(name="d"), edm.Asset)
+        assert isinstance(edm.JunctionPoint(name="j"), edm.Asset)
+
+    def test_edge_equipment_is_asset(self):
+        assert isinstance(edm.Line(name="l"), edm.Asset)
+        assert isinstance(edm.Transformer(name="t"), edm.Asset)
+        assert isinstance(edm.Pipe(name="p"), edm.Asset)
+        assert isinstance(edm.Interconnection(name="ic"), edm.Asset)
+
+    def test_area_is_not_asset(self):
+        assert not isinstance(edm.BiddingZone(name="z"), edm.Asset)
+        assert not isinstance(edm.Country(name="c"), edm.Asset)
+
+    def test_collection_is_not_asset(self):
+        assert not isinstance(edm.Portfolio(name="p"), edm.Asset)
+        assert not isinstance(edm.Site(name="s"), edm.Asset)
+        assert not isinstance(edm.Region(name="r"), edm.Asset)
+
+    def test_commissioning_date(self):
+        from datetime import date
+        t = edm.WindTurbine(name="t", commissioning_date=date(2020, 1, 1))
+        assert t.commissioning_date == date(2020, 1, 1)
+
+
+class TestNodeAssetEdgeAsset:
+    def test_wind_turbine_is_node_asset(self):
+        t = edm.WindTurbine(name="t", capacity=3.0)
+        assert isinstance(t, edm.NodeAsset)
+        assert isinstance(t, edm.Node)
+        assert isinstance(t, edm.Asset)
+        assert isinstance(t, edm.Element)
+
+    def test_line_is_edge_asset(self):
+        l = edm.Line(name="L", capacity=100)
+        assert isinstance(l, edm.EdgeAsset)
+        assert isinstance(l, edm.Edge)
+        assert isinstance(l, edm.Asset)
+        assert isinstance(l, edm.Element)
+        assert not isinstance(l, edm.Node)
+
+    def test_sensor_mro(self):
+        s = edm.TemperatureSensor(name="t", height=2.0)
+        mro_names = [c.__name__ for c in type(s).__mro__]
+        assert "Sensor" in mro_names
+        assert "NodeAsset" in mro_names
+        assert "Node" in mro_names
+        assert "Asset" in mro_names
+        assert "Element" in mro_names
 
 
 class TestGridNode:
@@ -92,9 +145,20 @@ class TestGridNode:
 
 
 class TestSensor:
-    def test_height_on_subclass(self):
+    def test_height_on_base(self):
         s = edm.TemperatureSensor(name="T-sensor", height=2.0)
         assert s.height == 2.0
+
+    def test_all_weather_sensors_inherit_height(self):
+        for cls in (
+            edm.TemperatureSensor,
+            edm.WindSpeedSensor,
+            edm.RadiationSensor,
+            edm.RainSensor,
+            edm.HumiditySensor,
+        ):
+            s = cls(name="s", height=1.5)
+            assert s.height == 1.5
 
 
 class TestArea:
@@ -114,11 +178,11 @@ class TestArea:
 
 
 class TestCollection:
-    def test_portfolio_is_collection(self):
+    def test_portfolio_is_collection_not_asset(self):
         p = edm.Portfolio(name="P")
         assert isinstance(p, edm.Collection)
-        assert isinstance(p, edm.Node)
-        assert isinstance(p, edm.Entity)
+        assert isinstance(p, edm.Element)
+        assert not isinstance(p, edm.Asset)
 
     def test_site_is_collection(self):
         s = edm.Site(name="S")
@@ -127,3 +191,34 @@ class TestCollection:
     def test_network_is_collection(self):
         n = edm.Network(name="N")
         assert isinstance(n, edm.Collection)
+
+
+class TestDiamondMRO:
+    def test_wind_turbine_construction(self):
+        """Constructing a diamond class should initialize Element fields once."""
+        from datetime import date
+        t = edm.WindTurbine(
+            name="t",
+            commissioning_date=date(2020, 1, 1),
+            capacity=3.0,
+            hub_height=100.0,
+        )
+        assert t.name == "t"
+        assert t.commissioning_date == date(2020, 1, 1)
+        assert t.capacity == 3.0
+        assert t.hub_height == 100.0
+        # Inherited collection field initialized exactly once to an empty list.
+        assert t.members == []
+        assert t.timeseries == []
+
+    def test_line_construction(self):
+        l = edm.Line(
+            name="L",
+            from_entity=edm.Reference("A"),
+            to_entity=edm.Reference("B"),
+            capacity=100.0,
+        )
+        assert l.name == "L"
+        assert l.capacity == 100.0
+        assert l.directed is True
+        assert l.from_entity is not None

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,6 +1,8 @@
-"""Tests for JSON round-trip of Entity trees."""
+"""Tests for JSON round-trip of Element trees."""
 
 import json
+from datetime import date, tzinfo
+from zoneinfo import ZoneInfo
 
 import pytest
 from shapely.geometry import Point, Polygon
@@ -154,6 +156,23 @@ class TestValueTypeRoundTrip:
         assert out.type == "renewable"
 
 
+class TestDateAndTzRoundTrip:
+    def test_commissioning_date_round_trip(self):
+        b = edm.Battery(name="B", commissioning_date=date(2020, 6, 1))
+        wrapper = edm.Portfolio(name="root", members=[b])
+        restored = edm.Portfolio.from_json(wrapper.to_json())
+        out = restored.members[0]
+        assert isinstance(out.commissioning_date, date)
+        assert out.commissioning_date == date(2020, 6, 1)
+
+    def test_tz_round_trip_zoneinfo(self):
+        s = edm.Site(name="S", tz=ZoneInfo("Europe/Stockholm"))
+        wrapper = edm.Portfolio(name="root", members=[s])
+        restored = edm.Portfolio.from_json(wrapper.to_json())
+        out = restored.members[0].tz
+        assert isinstance(out, tzinfo)
+        assert getattr(out, "key", None) == "Europe/Stockholm"
+
 class TestSynchronousArea:
     def test_round_trip_with_nominal_frequency(self):
         nsa = edm.SynchronousArea(
@@ -169,3 +188,192 @@ class TestSynchronousArea:
         assert len(out.timeseries) == 1
         assert out.timeseries[0].name == "frequency.state.area"
         assert out.timeseries[0].unit == "Hz"
+
+
+def _kitchen_sink_portfolio():
+    """A tree that exercises every round-trip path at once.
+
+    Covers, in one structure:
+      * Portfolio → MultiSite → Site → NodeAsset nesting (three levels of
+        ``members``).
+      * Point and Polygon geometries on assets and areas.
+      * ``ZoneInfo`` on two different levels (Collection and House).
+      * ``commissioning_date`` on an Asset.
+      * Multiple ``TimeSeriesDescriptor``s from the energy vocabulary, mixed
+        units/data_types.
+      * ``Carrier`` value type on a ``JunctionPoint``.
+      * Two ``Interconnection`` edges, one pointing into a deeply nested
+        ``BiddingZone`` (path contains multiple segments) and one pointing to
+        a sibling — both exercise :class:`Reference` path resolution.
+      * ``SynchronousArea`` with ``nominal_frequency``.
+    """
+    t01 = edm.WindTurbine(
+        name="T01", capacity=3.5, hub_height=80,
+        geometry=Point(12.78, 55.51),
+        commissioning_date=date(2019, 4, 1),
+        timeseries=[edm.electricity_supply(unit="MW", data_type=DataType.FORECAST)],
+    )
+    t02 = edm.WindTurbine(
+        name="T02", capacity=3.5, hub_height=80,
+        geometry=Point(12.79, 55.52),
+        timeseries=[edm.electricity_supply(unit="MW", data_type=DataType.ACTUAL)],
+    )
+    lillgrund = edm.WindFarm(name="Lillgrund", capacity=110, members=[t01, t02])
+
+    bat = edm.Battery(
+        name="Bat1", storage_capacity=10, max_charge=5, max_discharge=5,
+        commissioning_date=date(2022, 1, 15),
+    )
+    hp = edm.HeatPump(
+        name="HP1", capacity=8, cop=3.5, energy_source="electricity",
+        timeseries=[edm.heating_demand(unit="kW")],
+    )
+    house = edm.House(
+        name="House-42",
+        geometry=Point(11.97, 57.71),
+        tz=ZoneInfo("Europe/Stockholm"),
+        members=[hp, bat],
+    )
+
+    site_a = edm.Site(
+        name="Sweden-Offshore",
+        geometry=Point(12.8, 55.5),
+        tz=ZoneInfo("Europe/Stockholm"),
+        members=[lillgrund, house],
+    )
+    multi = edm.MultiSite(name="Nordic-Cluster", members=[site_a])
+
+    se4_poly = Polygon([(12.5, 55.0), (16.5, 55.0), (16.5, 58.0), (12.5, 58.0)])
+    dk2_poly = Polygon([(11.0, 54.5), (12.8, 54.5), (12.8, 56.0), (11.0, 56.0)])
+    se4 = edm.BiddingZone(
+        name="SE4", geometry=se4_poly,
+        timeseries=[edm.spot_price(unit="EUR / MWh")],
+    )
+    dk2 = edm.BiddingZone(
+        name="DK2", geometry=dk2_poly,
+        timeseries=[edm.spot_price(unit="EUR / MWh")],
+    )
+    nsa = edm.SynchronousArea(
+        name="NSA-Nordic", nominal_frequency=50.0,
+        members=[se4, dk2],
+        timeseries=[edm.grid_frequency()],
+    )
+
+    electricity = edm.Carrier(name="electricity", type="renewable")
+    bus = edm.JunctionPoint(name="BusA", carrier=electricity)
+
+    icx_nested = edm.Interconnection(
+        name="Line-into-SE4",
+        from_entity=edm.Reference("BusA"),
+        to_entity=edm.Reference("NSA-Nordic/SE4"),
+        capacity_forward=1700, capacity_backward=1300,
+        timeseries=[edm.cross_border_flow(unit="MW")],
+    )
+    icx_sibling = edm.Interconnection(
+        name="SE4-DK2",
+        from_entity=edm.Reference("NSA-Nordic/SE4"),
+        to_entity=edm.Reference("NSA-Nordic/DK2"),
+        capacity_forward=2000, capacity_backward=2000,
+    )
+
+    return edm.Portfolio(
+        name="Kitchen-Sink",
+        members=[multi, nsa, bus, icx_nested, icx_sibling],
+    )
+
+
+class TestKitchenSinkRoundTrip:
+    """End-to-end round-trip across every feature combined in one tree."""
+
+    def test_byte_equal_round_trip(self):
+        p = _kitchen_sink_portfolio()
+        js = p.to_json()
+        restored = edm.Portfolio.from_json(js)
+        assert json.dumps(js, default=str) == json.dumps(restored.to_json(), default=str)
+
+    def test_idempotent_on_second_round_trip(self):
+        # dump → load → dump → load must stabilize after the first cycle.
+        p = _kitchen_sink_portfolio()
+        js1 = p.to_json()
+        js2 = edm.Portfolio.from_json(js1).to_json()
+        js3 = edm.Portfolio.from_json(js2).to_json()
+        assert json.dumps(js2, default=str) == json.dumps(js3, default=str)
+
+    def test_deep_structure_preserved(self):
+        restored = edm.Portfolio.from_json(_kitchen_sink_portfolio().to_json())
+        multi = restored.members[0]
+        assert isinstance(multi, edm.MultiSite)
+        site = multi.members[0]
+        assert isinstance(site, edm.Site)
+        # Site → [WindFarm, House]; WindFarm → [T01, T02]; House → [HP1, Bat1]
+        farm, house = site.members
+        assert isinstance(farm, edm.WindFarm)
+        assert [t.name for t in farm.members] == ["T01", "T02"]
+        assert isinstance(house, edm.House)
+        assert {type(m).__name__ for m in house.members} == {"HeatPump", "Battery"}
+
+    def test_geometry_types_preserved(self):
+        restored = edm.Portfolio.from_json(_kitchen_sink_portfolio().to_json())
+        site = restored.members[0].members[0]
+        farm = site.members[0]
+        assert isinstance(farm.members[0].geometry, Point)
+        assert isinstance(site.geometry, Point)
+        nsa = restored.members[1]
+        for zone in nsa.members:
+            assert isinstance(zone.geometry, Polygon)
+
+    def test_tz_at_multiple_levels(self):
+        restored = edm.Portfolio.from_json(_kitchen_sink_portfolio().to_json())
+        site = restored.members[0].members[0]
+        house = site.members[1]
+        assert isinstance(site.tz, tzinfo)
+        assert isinstance(house.tz, tzinfo)
+        assert getattr(site.tz, "key", None) == "Europe/Stockholm"
+        assert getattr(house.tz, "key", None) == "Europe/Stockholm"
+
+    def test_references_resolve_across_nesting(self):
+        # ``SE4`` and ``DK2`` live under NSA (nested), not as direct siblings
+        # of the edges. Reference resolution must search the whole tree.
+        restored = edm.Portfolio.from_json(_kitchen_sink_portfolio().to_json())
+        edges = [m for m in restored.members if isinstance(m, edm.Interconnection)]
+        assert len(edges) == 2
+        nested = next(e for e in edges if e.name == "Line-into-SE4")
+        sibling = next(e for e in edges if e.name == "SE4-DK2")
+        assert nested.from_entity.is_resolved()
+        assert nested.to_entity.is_resolved()
+        assert nested.to_entity.get().name == "SE4"
+        assert isinstance(nested.to_entity.get(), edm.BiddingZone)
+        assert sibling.from_entity.get() is not sibling.to_entity.get()
+        assert sibling.from_entity.get().name == "SE4"
+        assert sibling.to_entity.get().name == "DK2"
+
+    def test_value_types_and_dates_preserved(self):
+        restored = edm.Portfolio.from_json(_kitchen_sink_portfolio().to_json())
+        bus = next(m for m in restored.members if isinstance(m, edm.JunctionPoint))
+        assert isinstance(bus.carrier, edm.Carrier)
+        assert bus.carrier.type == "renewable"
+
+        site = restored.members[0].members[0]
+        t01 = site.members[0].members[0]
+        assert t01.commissioning_date == date(2019, 4, 1)
+        battery = site.members[1].members[1]
+        assert battery.commissioning_date == date(2022, 1, 15)
+
+    def test_timeseries_descriptors_preserved(self):
+        restored = edm.Portfolio.from_json(_kitchen_sink_portfolio().to_json())
+        t01 = restored.members[0].members[0].members[0].members[0]
+        assert t01.timeseries[0].name == "electricity.supply"
+        assert t01.timeseries[0].data_type == DataType.FORECAST
+        nsa = restored.members[1]
+        assert nsa.nominal_frequency == 50.0
+        assert nsa.timeseries[0].unit == "Hz"
+
+    def test_include_ids_flag_round_trips(self):
+        # With ``include_ids=True`` every Element's ``_id`` must survive the trip.
+        p = _kitchen_sink_portfolio()
+        js = p.to_json(include_ids=True)
+        restored = edm.Portfolio.from_json(js)
+        assert restored._id == p._id
+        # Descend to an asset and compare.
+        assert restored.members[0].members[0].members[0].members[0]._id == \
+               p.members[0].members[0].members[0].members[0]._id

--- a/tests/test_tree_methods.py
+++ b/tests/test_tree_methods.py
@@ -167,7 +167,7 @@ class TestAddChild:
 
     def test_windturbine_accepts_any_element(self):
         # In the new flat ontology, every Node supports add_child by default.
-        # WindTurbine doesn't override it, so it accepts any Entity member.
+        # WindTurbine doesn't override it, so it accepts any Element member.
         t = edm.WindTurbine(name="T01", capacity=3.5)
         t2 = edm.WindTurbine(name="T02", capacity=3.5)
         t.add_child(t2)


### PR DESCRIPTION
## Summary

- Renames the old `Entity` tree to `Element`, and splits the hierarchy into three siblings under `Element`: `Node` (graph vertices), `Edge` (relationships), `Collection` (logical groupings). `Asset` becomes a cross-cutting mixin (`NodeAsset`, `EdgeAsset`) — never a leaf type.
- Replaces ad-hoc `TimeSeries` subclasses with a vocabulary of constructors (`electricity_supply`, `spot_price`, `grid_frequency`, `heating_demand`, ...) that emit typed `TimeSeriesDescriptor` values.
- Adds a typed JSON round-trip: Elements, `TimeSeriesDescriptor`, Shapely geometries, tuples, `ZoneInfo` timezones, dates, and registered value types (e.g. `Carrier`) all survive `to_json` → `from_json` with their Python types intact.
- Adds `Reference[T]` for cross-tree links by canonical path (`"NSA-Nordic/SE4"`), resolved lazily after load.
- Drops `pytz`: all `tz` fields are now `Optional[datetime.tzinfo]`, constructed via `zoneinfo.ZoneInfo`. `tzdata` is pulled in on Windows.
- No backwards-compat aliases. Callers using `Entity`, `EnergyAsset`, `EnergyCollection`, `entity_to_json`, `entity_from_json`, or `register_entity` must update imports.

## New public API

- `element_to_json` / `element_from_json` / `register_element` / `register_builtin_elements` (replaces `entity_*`).
- `Reference[T]` on `Edge.from_entity` / `Edge.to_entity`, with `resolve()`, `get()`, `is_resolved()`, `path(root)`.
- Energy vocabulary constructors + `build_metric(Quantity, Kind, Scope)` for custom metric names.

## Breaking changes

- `Entity` → `Element` (module `energydatamodel.entity` → `energydatamodel.element`).
- `EnergyAsset` / `EnergyCollection` replaced by `NodeAsset` / `Collection`.
- JSON helpers renamed as above. No aliases kept.
- `tz` attributes are `zoneinfo.ZoneInfo` after JSON round-trip, not `pytz.timezone`. Code that did `tz.zone` must use `tz.key` or `str(tz)`.
- `pytz` removed from `pyproject.toml` dependencies.
- Subclass-based time-series types replaced by vocabulary constructors returning `TimeSeriesDescriptor`.

## Docs

- README class-hierarchy diagram + module table rewritten.
- `docs/energydatamodel/base.rst` regenerated for `Element` / `Node` / `Edge` / `Collection` / `Asset`.
- `docs/quickstart.rst` replaced with a runnable `Portfolio → Site → {PV, Wind, Battery}` example.
- `examples/quickstart.ipynb` re-executed end-to-end; `pytz` removed.
